### PR TITLE
update readme - add https to composer link

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,7 +14,7 @@ The word _Jikan_ literally translates to _Time_ in Japanese (**時間**). And th
 ## Getting Started
 
 ### Requirements
-- [Composer](getcomposer.org/download/)
+- [Composer](https://getcomposer.org/download/)
 - [Redis](https://redis.io)
 - PHP 7.1+
 


### PR DESCRIPTION
The link to download composer on the README currently takes me to https://github.com/jikan-me/jikan-rest/blob/master/getcomposer.org/download, added https to fix that.