### PR TITLE
add reasoning for python-software-properties/common

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -31,8 +31,9 @@ This is specifically for Ubuntu, but other distributions should work similarly.
 
 1. Install requirements:
   - Add PHP related packages: `sudo add-apt-repository -y ppa:ondrej/php`
+    - If `add-apt-repository` is not installed, you can install it by doing `sudo apt install python-software-properties` or `sudo apt install software-properties-common`
   - `sudo apt update && sudo apt upgrade`
-  - Install requirements: `sudo apt install curl git python-software-properties php redis-server unzip`
+  - Install requirements: `sudo apt install curl git php redis-server unzip`
   - Verify that PHP 7.1+ is installed: `php -v`
   - Install the corresponding `php-xml` and `php-mbstring` packages for your version, e.g:
     - PHP 7.1: `sudo apt install php7.1-xml php7.1-mbstring`


### PR DESCRIPTION
the python-software-properties/software-properties-common install may not be necessary if add-apt-repository already exists on someones system, fix the installation instructions accordingly