### PR TITLE
Make Jikan-go naming consistent

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -33,7 +33,7 @@ It's built on the Lumen microframework, uses Redis for caching and is powered by
 - [Dart - Jikan-dart](https://github.com/charafau/jikan-dart) by Rafal Wachol
 - [TypeScript - Jikants](https://github.com/Julien-Broyard/jikants) by Julien Broyard
 - [TypeScript - jikan-client](https://github.com/javi11/jikan-client) by Javier Blanco
-- [Go - Jikan-Go](https://github.com/darenliang/jikan-go) by Daren Liang
+- [Go - Jikan-go](https://github.com/darenliang/jikan-go) by Daren Liang
 
 [Add your wrapper here!](https://github.com/jikan-me/jikan-rest/edit/master/apiary.apib)
 


### PR DESCRIPTION
The "go" at the end of Jikan-go shouldn't be capitalized.