### PR TITLE
Group wrappers by language in the README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -189,7 +189,7 @@ If you don't want to host your instance, there's a public API available.
 | Dart       | [jikan-dart](https://github.com/charafau/jikan-dart) by Rafal Wachol |
 | Elixir     | [JikanEx](https://github.com/seanbreckenridge/jikan_ex) by Sean Breckenridge |
 | Go         | [jikan-go](https://github.com/darenliang/jikan-go) by Daren Liang<br>[jikan2go](https://github.com/nokusukun/jikan2go) by nokusukun |
-| Java       | [Jikan4java](https://github.com/Doomsdayrs/Jikan4java) by Doomsdayrs<br>[Java Jikan Client](https://github.com/Schalar/Jikan) by Schalar |
+| Java       | [Jikan4java](https://github.com/Doomsdayrs/Jikan4java) by Doomsdayrs<br>[Java Jikan Client](https://github.com/Schalar/Jikan) by Schalar<br>[reactive-jikan](https://github.com/SandroHc/reactive-jikan) by Sandro Marques |
 | JavaScript | [JikanJS](https://github.com/zuritor/jikanjs) by Zuritor |
 | Kotlin     | [JikanKt](https://github.com/GSculerlor/JikanKt) by Ganedra Afrasya |
 | Node.js    | [jikan-node](https://github.com/xy137/jikan-node) by xy137 |

--- a/README.MD
+++ b/README.MD
@@ -182,18 +182,21 @@ If you don't want to host your instance, there's a public API available.
 - **[Apps/Projects using JikanREST](https://jikan.moe/showcase)**
 
 ## Wrappers
-- **[.NET]** [Jikan.net](https://github.com/Ervie/jikan.net) by Ervie
-- **[Python]** [JikanPy](https://github.com/abhinavk99/jikanpy) by Abhinav Kasamsetty
-- **[Ruby]** [Jikan.rb](https://github.com/Zerocchi/jikan.rb) by Zerocchi
-- **[JavaScript]** [JikanJS](https://github.com/zuritor/jikanjs) by Zuritor
-- **[Java]** [Jikan4java](https://github.com/Doomsdayrs/Jikan4java) by Doomsdayrs
-- **[PHP]** [jikan-php](https://github.com/janvernieuwe/jikan-jikanPHP) by Jan Vernieuwe
-- **[Node.js]** [jikan-node](https://github.com/xy137/jikan-node) by xy137
-- **[Dart]** [jikan-dart](https://github.com/charafau/jikan-dart) by Rafal Wachol
-- **[TypeScript]** [jikants](https://github.com/Julien-Broyard/jikants) by Julien Broyard
-- **[TypeScript]** [jikan-client](https://github.com/javi11/jikan-client) by Javier Blanco
-- **[Go]** [jikan-go](https://github.com/darenliang/jikan-go) by Daren Liang
-- **[Elixir]** [JikanEx](https://github.com/seanbreckenridge/jikan_ex) by Sean Breckenridge
+
+| Language   | Wrappers |
+|------------|----------|
+| .NET       | [Jikan.net](https://github.com/Ervie/jikan.net) by Ervie |
+| Dart       | [jikan-dart](https://github.com/charafau/jikan-dart) by Rafal Wachol |
+| Elixir     | [JikanEx](https://github.com/seanbreckenridge/jikan_ex) by Sean Breckenridge |
+| Go         | [jikan-go](https://github.com/darenliang/jikan-go) by Daren Liang<br>[jikan2go](https://github.com/nokusukun/jikan2go) by nokusukun |
+| Java       | [Jikan4java](https://github.com/Doomsdayrs/Jikan4java) by Doomsdayrs<br>[Java Jikan Client](https://github.com/Schalar/Jikan) by Schalar |
+| JavaScript | [JikanJS](https://github.com/zuritor/jikanjs) by Zuritor |
+| Kotlin     | [JikanKt](https://github.com/GSculerlor/JikanKt) by Ganedra Afrasya |
+| Node.js    | [jikan-node](https://github.com/xy137/jikan-node) by xy137 |
+| PHP        | [jikan-php](https://github.com/janvernieuwe/jikan-jikanPHP) by Jan Vernieuwe |
+| Python     | [JikanPy](https://github.com/abhinavk99/jikanpy) by Abhinav Kasamsetty |
+| Ruby       | [Jikan.rb](https://github.com/Zerocchi/jikan.rb) by Zerocchi |
+| TypeScript | [jikants](https://github.com/Julien-Broyard/jikants) by Julien Broyard<br>[jikan-client](https://github.com/javi11/jikan-client) by Javier Blanco |
 
 [Add your wrapper here](https://github.com/jikan-me/jikan/edit/master/readme.md)
 


### PR DESCRIPTION
The list of languages was sorted alphabetically.

Also added a few missing wrappers (from the website):
 - JikanKt by Ganedra Afrasya
 - jikan2go by nokusukun
 - Java Jikan Client by Schalar
 - Reactive Jikan by me (I also created a PR to add it to the website)

Not sure what to do with similar languages (like Java and Kotlin, or JavaScript and TypeScript).