### PR TITLE
[DOC] Update all anime endpoints to reflect implementation 1:1

### DIFF
--- a/app/Http/Controllers/V4DB/AnimeController.php
+++ b/app/Http/Controllers/V4DB/AnimeController.php
@@ -518,15 +518,12 @@ class AnimeController extends Controller
      *      schema="anime news",
      *      description="Anime News Resource",
      *
-     *     @OA\Property(
-     *          property="data",
-     *          type="object",
-     *
-     *          allOf={
-     *              @OA\Schema(ref="#/components/schemas/pagination"),
-     *              @OA\Schema(ref="#/components/schemas/news"),
-     *          }
-     *     ),
+     *      allOf={
+     *          @OA\Schema(ref="#/components/schemas/pagination"),
+     *          @OA\Schema(
+     *              ref="#/components/schemas/news",
+     *          ),
+     *      }
      *  )
      */
     public function news(Request $request, int $id)

--- a/app/Http/Controllers/V4DB/AnimeController.php
+++ b/app/Http/Controllers/V4DB/AnimeController.php
@@ -740,13 +740,37 @@ class AnimeController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns a list of anime forum topics",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/anime pictures"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
      *         description="Error: Bad request. When required parameters were not supplied.",
      *     ),
      * )
+     * 
+     *  @OA\Schema(
+     *      schema="anime pictures",
+     *      description="Anime Pictures",
+     *      @OA\Property(
+     *          property="data",
+     *          type="array",
+     * 
+     *          @OA\Items(
+     *              @OA\Property(
+     *                  property="image_url",
+     *                  type="string",
+     *                  description="Default JPG Image Size URL"
+     *              ),
+     *              @OA\Property(
+     *                  property="large_image_url",
+     *                  type="string",
+     *                  description="Large JPG Image Size URL"
+     *              ),
+     *          )
+     *      )
+     *  )
      */
     public function pictures(Request $request, int $id)
     {

--- a/app/Http/Controllers/V4DB/AnimeController.php
+++ b/app/Http/Controllers/V4DB/AnimeController.php
@@ -55,7 +55,10 @@ class AnimeController extends Controller
      *         response="200",
      *         description="Returns anime resource",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/anime"
+     *              @OA\Property( 
+     *                  property="data",
+     *                  ref="#/components/schemas/anime"
+     *              )
      *         )
      *     ),
      *     @OA\Response(

--- a/app/Http/Controllers/V4DB/MangaController.php
+++ b/app/Http/Controllers/V4DB/MangaController.php
@@ -202,7 +202,9 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns a list of manga news topics",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/manga news"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
@@ -214,15 +216,10 @@ class MangaController extends Controller
      *      schema="manga news",
      *      description="Manga News Resource",
      *
-     *     @OA\Property(
-     *          property="data",
-     *          type="object",
-     *
-     *          allOf={
-     *              @OA\Schema(ref="#/components/schemas/pagination"),
-     *              @OA\Schema(ref="#/components/schemas/news"),
-     *          }
-     *     ),
+     *      allOf={
+     *          @OA\Schema(ref="#/components/schemas/pagination"),
+     *          @OA\Schema(ref="#/components/schemas/news"),
+     *      }
      *  )
      */
     public function news(Request $request, int $id)

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -54,7 +54,9 @@ class SearchController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns search results for anime",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/anime search"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",

--- a/app/Http/Resources/V4/AnimeCharactersResource.php
+++ b/app/Http/Resources/V4/AnimeCharactersResource.php
@@ -47,19 +47,26 @@ class AnimeCharactersResource extends JsonResource
      *                   type="array",
      *                   @OA\Items(
      *                       type="object",
-     *                       allOf={
-     *                           @OA\Schema(ref="#/components/schemas/mal_url"),
-     *                           @OA\Schema(
-     *                               @OA\Property(
-     *                                   property="image_url",
-     *                                   type="string",
-     *                               ),
-     *                               @OA\Property(
-     *                                   property="language",
-     *                                   type="string",
-     *                               ),
-     *                           ),
-     *                       },
+     *                       @OA\Property(
+     *                           property="mal_id",
+     *                           type="integer",
+     *                       ),
+     *                       @OA\Property(
+     *                           property="name",
+     *                           type="string",
+     *                       ),
+     *                       @OA\Property(
+     *                           property="url",
+     *                           type="string",
+     *                       ),
+     *                       @OA\Property(
+     *                           property="image_url",
+     *                           type="string",
+     *                       ),
+     *                       @OA\Property(
+     *                           property="language",
+     *                           type="string",
+     *                       ),
      *                   ),
      *               ),
      *          ),

--- a/app/Http/Resources/V4/AnimeCollection.php
+++ b/app/Http/Resources/V4/AnimeCollection.php
@@ -14,18 +14,24 @@ class AnimeCollection extends ResourceCollection
      * @var string
      *
      *  @OA\Schema(
-     *      schema="anime collection",
+     *      schema="anime search",
      *      description="Anime Collection Resource",
      *
-     *     @OA\Property(
-     *          property="data",
-     *          type="object",
+     *      allOf={
+     *          @OA\Schema(ref="#/components/schemas/pagination"),
+     *          @OA\Schema(
+     *              @OA\Property(
+     *                   property="data",
+     *                   type="array",
      *
-     *          allOf={
-     *              @OA\Schema(ref="#/components/schemas/pagination"),
-     *              @OA\Schema(ref="#/components/schemas/anime"),
-     *          }
-     *     ),
+     *                   @OA\Items(
+     *                       allOf={
+     *                           @OA\Schema(ref="#/components/schemas/anime"),
+     *                       }
+     *                   )
+     *              ),
+     *          )
+     *      }
      *  )
      */
     public $collects = 'App\Http\Resources\V4\AnimeResource';

--- a/app/Http/Resources/V4/AnimeResource.php
+++ b/app/Http/Resources/V4/AnimeResource.php
@@ -68,7 +68,7 @@ class AnimeResource extends JsonResource
      *      ),
      *      @OA\Property(
      *          property="trailer",
-     *          ref="#/components/schemas/trailer"
+     *          ref="#/components/schemas/trailer base"
      *      ),
      *
      *      @OA\Property(

--- a/app/Http/Resources/V4/AnimeStaffResource.php
+++ b/app/Http/Resources/V4/AnimeStaffResource.php
@@ -34,6 +34,11 @@ class AnimeStaffResource extends JsonResource
      *                   description="Name"
      *               ),
      *               @OA\Property(
+     *                   property="image_url",
+     *                   type="string",
+     *                   description="MyAnimeList Image URL"
+     *               ),
+     *               @OA\Property(
      *                   property="positions",
      *                   type="array",
      *                   description="Staff Positions",

--- a/app/Http/Resources/V4/AnimeStatisticsResource.php
+++ b/app/Http/Resources/V4/AnimeStatisticsResource.php
@@ -57,11 +57,6 @@ class AnimeStatisticsResource extends JsonResource
      *               @OA\Items(
      *                   type="object",
      *                   @OA\Property(
-     *                       property="score",
-     *                       type="integer",
-     *                       description="The number Score"
-     *                   ),
-     *                   @OA\Property(
      *                       property="votes",
      *                       type="integer",
      *                       description="Number of votes for this score"

--- a/app/Http/Resources/V4/CommonResource.php
+++ b/app/Http/Resources/V4/CommonResource.php
@@ -11,6 +11,17 @@ class CommonResource extends JsonResource
      *      schema="trailer",
      *      type="object",
      *      description="Youtube Details",
+     *      
+     *      allOf={
+     *          @OA\Schema(ref="#/components/schemas/trailer base"),
+     *          @OA\Schema(ref="#/components/schemas/trailer images"),
+     *      } 
+     *  ),
+     * 
+     *  @OA\Schema(
+     *      schema="trailer base",
+     *      type="object",
+     *      description="Youtube Details",
      *
      *      @OA\Property(
      *          property="youtube_id",
@@ -27,7 +38,14 @@ class CommonResource extends JsonResource
      *          type="string",
      *          description="Parsed Embed URL"
      *      ),
-     *     @OA\Property(
+     *  ),
+     * 
+     *  @OA\Schema(
+     *      schema="trailer images",
+     *      type="object",
+     *      description="Youtube Images",
+     *
+     *      @OA\Property(
      *          property="images",
      *          type="object",
      *          @OA\Property(

--- a/app/Http/Resources/V4/CommonResource.php
+++ b/app/Http/Resources/V4/CommonResource.php
@@ -391,7 +391,7 @@ class CommonResource extends JsonResource
      *         description="Review content"
      *     ),
      *     @OA\Property(
-     *         property="reviewer",
+     *         property="author",
      *         type="object",
      *         description="Reviewer details",
      *         @OA\Property(
@@ -413,6 +413,41 @@ class CommonResource extends JsonResource
      *             property="episodes_seen",
      *             type="integer",
      *             description="Number of episodes seen"
+     *         ),
+     *         @OA\Property(
+     *             property="scores",
+     *             type="object",
+     *             description="Review Scores breakdown",
+     *             @OA\Property(
+     *                 property="overall",
+     *                 type="integer",
+     *                 description="Overall Score"
+     *             ),
+     *             @OA\Property(
+     *                 property="story",
+     *                 type="integer",
+     *                 description="Story Score"
+     *             ),
+     *             @OA\Property(
+     *                 property="animation",
+     *                 type="integer",
+     *                 description="Animation Score"
+     *             ),
+     *             @OA\Property(
+     *                 property="sound",
+     *                 type="integer",
+     *                 description="Sound Score"
+     *             ),
+     *             @OA\Property(
+     *                 property="character",
+     *                 type="integer",
+     *                 description="Character Score"
+     *             ),
+     *             @OA\Property(
+     *                 property="enjoyment",
+     *                 type="integer",
+     *                 description="Enjoyment Score"
+     *             ),
      *         ),
      *     ),
      *  ),

--- a/app/Http/Resources/V4/CommonResource.php
+++ b/app/Http/Resources/V4/CommonResource.php
@@ -264,7 +264,7 @@ class CommonResource extends JsonResource
      *     schema="news",
      *     type="object",
      *     @OA\Property(
-     *          property="results",
+     *          property="data",
      *          type="array",
      *          @OA\Items(
      *              type="object",

--- a/app/Http/Resources/V4/CommonResource.php
+++ b/app/Http/Resources/V4/CommonResource.php
@@ -31,7 +31,7 @@ class CommonResource extends JsonResource
      *          property="images",
      *          type="object",
      *          @OA\Property(
-     *              property="image_url",
+     *              property="default_image_url",
      *              type="string",
      *              description="Default Image Size URL (120x90)"
      *          ),

--- a/app/Http/Resources/V4/RecommendationsResource.php
+++ b/app/Http/Resources/V4/RecommendationsResource.php
@@ -33,6 +33,11 @@ class RecommendationsResource extends JsonResource
      *                  description="Recommended MyAnimeList URL"
      *              ),
      *              @OA\Property(
+     *                  property="image_url",
+     *                  type="string",
+     *                  description="Recommended MyAnimeList Image URL"
+     *              ),
+     *              @OA\Property(
      *                  property="recommendation_url",
      *                  type="string",
      *                  description="Recommendation MyAnimeList URL"

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -32,7 +32,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/anime"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/anime"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -215,7 +220,9 @@
                         "description": "Returns a list of anime forum topics",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/anime pictures"
+                                }
                             }
                         }
                     },
@@ -603,7 +610,9 @@
                         "description": "Returns a list of manga news topics",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/manga news"
+                                }
                             }
                         }
                     },
@@ -1044,7 +1053,9 @@
                         "description": "Returns search results for anime",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/anime search"
+                                }
                             }
                         }
                     },
@@ -1630,17 +1641,33 @@
             },
             "anime news": {
                 "description": "Anime News Resource",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/pagination"
+                    },
+                    {
+                        "$ref": "#/components/schemas/news"
+                    }
+                ]
+            },
+            "anime pictures": {
+                "description": "Anime Pictures",
                 "properties": {
                     "data": {
-                        "type": "object",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/pagination"
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "image_url": {
+                                    "description": "Default JPG Image Size URL",
+                                    "type": "string"
+                                },
+                                "large_image_url": {
+                                    "description": "Large JPG Image Size URL",
+                                    "type": "string"
+                                }
                             },
-                            {
-                                "$ref": "#/components/schemas/news"
-                            }
-                        ]
+                            "type": "object"
+                        }
                     }
                 },
                 "type": "object"
@@ -1673,20 +1700,14 @@
             },
             "manga news": {
                 "description": "Manga News Resource",
-                "properties": {
-                    "data": {
-                        "type": "object",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/pagination"
-                            },
-                            {
-                                "$ref": "#/components/schemas/news"
-                            }
-                        ]
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/pagination"
+                    },
+                    {
+                        "$ref": "#/components/schemas/news"
                     }
-                },
-                "type": "object"
+                ]
             },
             "random": {
                 "description": "Random Resources",
@@ -2216,23 +2237,24 @@
                                 "voice_actors": {
                                     "type": "array",
                                     "items": {
-                                        "type": "object",
-                                        "allOf": [
-                                            {
-                                                "$ref": "#/components/schemas/mal_url"
+                                        "properties": {
+                                            "mal_id": {
+                                                "type": "integer"
                                             },
-                                            {
-                                                "properties": {
-                                                    "image_url": {
-                                                        "type": "string"
-                                                    },
-                                                    "language": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "type": "object"
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "url": {
+                                                "type": "string"
+                                            },
+                                            "image_url": {
+                                                "type": "string"
+                                            },
+                                            "language": {
+                                                "type": "string"
                                             }
-                                        ]
+                                        },
+                                        "type": "object"
                                     }
                                 }
                             },
@@ -2242,23 +2264,29 @@
                 },
                 "type": "object"
             },
-            "anime collection": {
+            "anime search": {
                 "description": "Anime Collection Resource",
-                "properties": {
-                    "data": {
-                        "description": "The resource that this resource collects.",
-                        "type": "object",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/pagination"
-                            },
-                            {
-                                "$ref": "#/components/schemas/anime"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/pagination"
+                    },
+                    {
+                        "properties": {
+                            "data": {
+                                "description": "The resource that this resource collects.",
+                                "type": "array",
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/anime"
+                                        }
+                                    ]
+                                }
                             }
-                        ]
+                        },
+                        "type": "object"
                     }
-                },
-                "type": "object"
+                ]
             },
             "anime episode": {
                 "description": "Anime Episode Resource",
@@ -2365,7 +2393,7 @@
                         "type": "object"
                     },
                     "trailer": {
-                        "$ref": "#/components/schemas/trailer"
+                        "$ref": "#/components/schemas/trailer base"
                     },
                     "title": {
                         "description": "Title",
@@ -2558,6 +2586,10 @@
                                     "description": "Name",
                                     "type": "string"
                                 },
+                                "image_url": {
+                                    "description": "MyAnimeList Image URL",
+                                    "type": "string"
+                                },
                                 "positions": {
                                     "description": "Staff Positions",
                                     "type": "array",
@@ -2607,10 +2639,6 @@
                                 "type": "array",
                                 "items": {
                                     "properties": {
-                                        "score": {
-                                            "description": "The number Score",
-                                            "type": "integer"
-                                        },
                                         "votes": {
                                             "description": "Number of votes for this score",
                                             "type": "integer"
@@ -2982,6 +3010,18 @@
             },
             "trailer": {
                 "description": "Youtube Details",
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/trailer base"
+                    },
+                    {
+                        "$ref": "#/components/schemas/trailer images"
+                    }
+                ]
+            },
+            "trailer base": {
+                "description": "Youtube Details",
                 "properties": {
                     "youtube_id": {
                         "description": "YouTube ID",
@@ -2994,10 +3034,16 @@
                     "embed_url": {
                         "description": "Parsed Embed URL",
                         "type": "string"
-                    },
+                    }
+                },
+                "type": "object"
+            },
+            "trailer images": {
+                "description": "Youtube Images",
+                "properties": {
                     "images": {
                         "properties": {
-                            "image_url": {
+                            "default_image_url": {
                                 "description": "Default Image Size URL (120x90)",
                                 "type": "string"
                             },
@@ -3183,7 +3229,7 @@
             },
             "news": {
                 "properties": {
-                    "results": {
+                    "data": {
                         "type": "array",
                         "items": {
                             "properties": {
@@ -3290,7 +3336,7 @@
                         "description": "Review content",
                         "type": "string"
                     },
-                    "reviewer": {
+                    "author": {
                         "description": "Reviewer details",
                         "properties": {
                             "username": {
@@ -3308,6 +3354,36 @@
                             "episodes_seen": {
                                 "description": "Number of episodes seen",
                                 "type": "integer"
+                            },
+                            "scores": {
+                                "description": "Review Scores breakdown",
+                                "properties": {
+                                    "overall": {
+                                        "description": "Overall Score",
+                                        "type": "integer"
+                                    },
+                                    "story": {
+                                        "description": "Story Score",
+                                        "type": "integer"
+                                    },
+                                    "animation": {
+                                        "description": "Animation Score",
+                                        "type": "integer"
+                                    },
+                                    "sound": {
+                                        "description": "Sound Score",
+                                        "type": "integer"
+                                    },
+                                    "character": {
+                                        "description": "Character Score",
+                                        "type": "integer"
+                                    },
+                                    "enjoyment": {
+                                        "description": "Enjoyment Score",
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
                             }
                         },
                         "type": "object"
@@ -4365,6 +4441,10 @@
                                 },
                                 "url": {
                                     "description": "Recommended MyAnimeList URL",
+                                    "type": "string"
+                                },
+                                "image_url": {
+                                    "description": "Recommended MyAnimeList Image URL",
                                     "type": "string"
                                 },
                                 "recommendation_url": {


### PR DESCRIPTION
- /anime
  - Add search return schema
- /anime/{id}
  - Wrap it in `data` field
  - Fix `trailer` field
- /anime/{id}/characters
  - Remove the nonexistent `type` field in `voice actor`
- /anime/{id}/staff
  - Add `image_url` field
- /anime/{id}/news
  - Fix pagination
- /anime/{id}/pictures
  - Add pictures return schema
- /anime/{id}/statistics
  - Remove the nonexistent `score` field in `scores`
- /anime/{id}/recommendations
  - Add `image_url` field
- /anime/{id}/reviews
  - Rename `reviewer` to `author`
  - Add `scores` field
