### PR TITLE
[DOC] Manga endpoint

### DIFF
--- a/app/Http/Controllers/V4DB/MangaController.php
+++ b/app/Http/Controllers/V4DB/MangaController.php
@@ -54,7 +54,12 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns manga resource",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              @OA\Property( 
+     *                  property="data",
+     *                  ref="#/components/schemas/manga"
+     *              )
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
@@ -130,7 +135,9 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns manga characters resource",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/manga characters"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
@@ -287,7 +294,9 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns a list of manga forum topics",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/forum"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
@@ -360,12 +369,35 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns a list of manga forum topics",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/manga pictures"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
      *         description="Error: Bad request. When required parameters were not supplied.",
      *     ),
+     * )
+     * @OA\Schema(
+     *     schema="manga pictures",
+     *     description="Anime Pictures",
+     *     @OA\Property(
+     *         property="data",
+     *         type="array",
+     * 
+     *         @OA\Items(
+     *             @OA\Property(
+     *                 property="image_url",
+     *                 type="string",
+     *                 description="Default JPG Image Size URL"
+     *             ),
+     *             @OA\Property(
+     *                 property="large_image_url",
+     *                 type="string",
+     *                 description="Large JPG Image Size URL"
+     *             ),
+     *         )
+     *     )
      * )
      */
     public function pictures(Request $request, int $id)
@@ -432,7 +464,9 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns anime statistics",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/manga statistics"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
@@ -504,7 +538,9 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns manga moreinfo",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/moreinfo"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
@@ -576,7 +612,9 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns manga recommendations",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/recommendations"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
@@ -648,7 +686,9 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns manga user updates",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/manga userupdates"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",
@@ -721,7 +761,9 @@ class MangaController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns manga reviews",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/manga reviews"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -109,7 +109,9 @@ class SearchController extends Controller
      *     @OA\Response(
      *         response="200",
      *         description="Returns search results for manga",
-     *         @OA\JsonContent()
+     *         @OA\JsonContent(
+     *              ref="#/components/schemas/manga search"
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",

--- a/app/Http/Resources/V4/CommonResource.php
+++ b/app/Http/Resources/V4/CommonResource.php
@@ -539,6 +539,36 @@ class CommonResource extends JsonResource
      *             type="integer",
      *             description="Number of chapters read"
      *         ),
+     *         @OA\Property(
+     *             property="scores",
+     *             type="object",
+     *             description="Review Scores breakdown",
+     *             @OA\Property(
+     *                 property="overall",
+     *                 type="integer",
+     *                 description="Overall Score"
+     *             ),
+     *             @OA\Property(
+     *                 property="story",
+     *                 type="integer",
+     *                 description="Story Score"
+     *             ),
+     *             @OA\Property(
+     *                 property="art",
+     *                 type="integer",
+     *                 description="Animation Score"
+     *             ),
+     *             @OA\Property(
+     *                 property="character",
+     *                 type="integer",
+     *                 description="Character Score"
+     *             ),
+     *             @OA\Property(
+     *                 property="enjoyment",
+     *                 type="integer",
+     *                 description="Enjoyment Score"
+     *             ),
+     *         ),
      *     ),
      *  ),
      */

--- a/app/Http/Resources/V4/MangaCollection.php
+++ b/app/Http/Resources/V4/MangaCollection.php
@@ -16,16 +16,22 @@ class MangaCollection extends ResourceCollection
      *  @OA\Schema(
      *      schema="manga search",
      *      description="Manga Search Resource",
+     * 
+     *      allOf={
+     *          @OA\Schema(ref="#/components/schemas/pagination"),
+     *          @OA\Schema(
+     *              @OA\Property(
+     *                   property="data",
+     *                   type="array",
      *
-     *     @OA\Property(
-     *          property="data",
-     *          type="object",
-     *
-     *          allOf={
-     *              @OA\Schema(ref="#/components/schemas/pagination"),
-     *              @OA\Schema(ref="#/components/schemas/manga"),
-     *          }
-     *     ),
+     *                   @OA\Items(
+     *                       allOf={
+     *                           @OA\Schema(ref="#/components/schemas/manga"),
+     *                       }
+     *                   )
+     *              ),
+     *          )
+     *      }
      *  )
      */
     public $collects = 'App\Http\Resources\V4\MangaResource';

--- a/app/Http/Resources/V4/MangaResource.php
+++ b/app/Http/Resources/V4/MangaResource.php
@@ -122,7 +122,7 @@ class MangaResource extends JsonResource
      *          ref="#/components/schemas/daterange"
      *      ),
      *      @OA\Property(
-     *          property="scored",
+     *          property="score",
      *          type="number",
      *          format="float",
      *          description="Score"

--- a/app/Http/Resources/V4/MangaResource.php
+++ b/app/Http/Resources/V4/MangaResource.php
@@ -122,7 +122,7 @@ class MangaResource extends JsonResource
      *          ref="#/components/schemas/daterange"
      *      ),
      *      @OA\Property(
-     *          property="score",
+     *          property="scored",
      *          type="number",
      *          format="float",
      *          description="Score"
@@ -161,10 +161,6 @@ class MangaResource extends JsonResource
      *          property="background",
      *          type="string",
      *          description="Background"
-     *      ),
-     *      @OA\Property(
-     *          property="broadcast",
-     *          ref="#/components/schemas/broadcast"
      *      ),
      *      @OA\Property(
      *          property="related",

--- a/app/Http/Resources/V4/MangaStatisticsResource.php
+++ b/app/Http/Resources/V4/MangaStatisticsResource.php
@@ -57,11 +57,6 @@ class MangaStatisticsResource extends JsonResource
      *               @OA\Items(
      *                   type="object",
      *                   @OA\Property(
-     *                       property="score",
-     *                       type="integer",
-     *                       description="The number Score"
-     *                   ),
-     *                   @OA\Property(
      *                       property="votes",
      *                       type="integer",
      *                       description="Number of votes for this score"

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -568,7 +568,14 @@
                         "description": "Returns manga resource",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/manga"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
                             }
                         }
                     },
@@ -589,7 +596,9 @@
                         "description": "Returns manga characters resource",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/manga characters"
+                                }
                             }
                         }
                     },
@@ -633,7 +642,9 @@
                         "description": "Returns a list of manga forum topics",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/forum"
+                                }
                             }
                         }
                     },
@@ -654,7 +665,9 @@
                         "description": "Returns a list of manga forum topics",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/manga pictures"
+                                }
                             }
                         }
                     },
@@ -675,7 +688,9 @@
                         "description": "Returns anime statistics",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/manga statistics"
+                                }
                             }
                         }
                     },
@@ -696,7 +711,9 @@
                         "description": "Returns manga moreinfo",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/moreinfo"
+                                }
                             }
                         }
                     },
@@ -717,7 +734,9 @@
                         "description": "Returns manga recommendations",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/recommendations"
+                                }
                             }
                         }
                     },
@@ -738,7 +757,9 @@
                         "description": "Returns manga user updates",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/manga userupdates"
+                                }
                             }
                         }
                     },
@@ -759,7 +780,9 @@
                         "description": "Returns manga reviews",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/manga reviews"
+                                }
                             }
                         }
                     },
@@ -1076,7 +1099,9 @@
                         "description": "Returns search results for manga",
                         "content": {
                             "application/json": {
-                                "schema": {}
+                                "schema": {
+                                    "$ref": "#/components/schemas/manga search"
+                                }
                             }
                         }
                     },
@@ -1708,6 +1733,28 @@
                         "$ref": "#/components/schemas/news"
                     }
                 ]
+            },
+            "manga pictures": {
+                "description": "Anime Pictures",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "image_url": {
+                                    "description": "Default JPG Image Size URL",
+                                    "type": "string"
+                                },
+                                "large_image_url": {
+                                    "description": "Large JPG Image Size URL",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
             },
             "random": {
                 "description": "Random Resources",
@@ -3461,6 +3508,32 @@
                             "chapters_read": {
                                 "description": "Number of chapters read",
                                 "type": "integer"
+                            },
+                            "scores": {
+                                "description": "Review Scores breakdown",
+                                "properties": {
+                                    "overall": {
+                                        "description": "Overall Score",
+                                        "type": "integer"
+                                    },
+                                    "story": {
+                                        "description": "Story Score",
+                                        "type": "integer"
+                                    },
+                                    "art": {
+                                        "description": "Animation Score",
+                                        "type": "integer"
+                                    },
+                                    "character": {
+                                        "description": "Character Score",
+                                        "type": "integer"
+                                    },
+                                    "enjoyment": {
+                                        "description": "Enjoyment Score",
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
                             }
                         },
                         "type": "object"
@@ -3650,21 +3723,27 @@
             },
             "manga search": {
                 "description": "Manga Search Resource",
-                "properties": {
-                    "data": {
-                        "description": "The resource that this resource collects.",
-                        "type": "object",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/pagination"
-                            },
-                            {
-                                "$ref": "#/components/schemas/manga"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/pagination"
+                    },
+                    {
+                        "properties": {
+                            "data": {
+                                "description": "The resource that this resource collects.",
+                                "type": "array",
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/manga"
+                                        }
+                                    ]
+                                }
                             }
-                        ]
+                        },
+                        "type": "object"
                     }
-                },
-                "type": "object"
+                ]
             },
             "manga": {
                 "description": "Manga Resource",
@@ -3777,7 +3856,7 @@
                     "published": {
                         "$ref": "#/components/schemas/daterange"
                     },
-                    "score": {
+                    "scored": {
                         "description": "Score",
                         "type": "number",
                         "format": "float"
@@ -3809,9 +3888,6 @@
                     "background": {
                         "description": "Background",
                         "type": "string"
-                    },
-                    "broadcast": {
-                        "$ref": "#/components/schemas/broadcast"
                     },
                     "related": {
                         "$ref": "#/components/schemas/relation"
@@ -3875,10 +3951,6 @@
                                 "type": "array",
                                 "items": {
                                     "properties": {
-                                        "score": {
-                                            "description": "The number Score",
-                                            "type": "integer"
-                                        },
                                         "votes": {
                                             "description": "Number of votes for this score",
                                             "type": "integer"

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -3856,7 +3856,7 @@
                     "published": {
                         "$ref": "#/components/schemas/daterange"
                     },
-                    "scored": {
+                    "score": {
                         "description": "Score",
                         "type": "number",
                         "format": "float"


### PR DESCRIPTION
Updates docs for all manga endpoints

#### Worth to mention:
- `related` field in manga search `manga/` uses different schema than one used in `anime/` `anime/{id}` and `manga/{id}`. As it is the only one that does it differently for some reason I did not worry about it and I left it as is, so for now doc of manga search does no align with JSON response
- I believe that `scores` field in `manga/{id}/reviews` and `anime/{id}/reviews` is duplicated inside of `reviewer` field