### PR TITLE
[DOC] Query parameters for search endpoints

### DIFF
--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -56,6 +56,13 @@ class SearchController extends Controller
      *    in="query",
      *    @OA\Schema(type="number")
      *  ),
+     * 
+     * @OA\Schema(
+     *   schema="search query sort",
+     *   description="Characters Search Query Sort",
+     *   type="string",
+     *   enum={"desc","asc"}
+     * )
      */
 
     /**
@@ -118,7 +125,7 @@ class SearchController extends Controller
      *     @OA\Parameter(
      *       name="sort",
      *       in="query",
-     *       @OA\Schema(ref="#/components/schemas/anime search query sort")
+     *       @OA\Schema(ref="#/components/schemas/search query sort")
      *     ),
      * 
      *     @OA\Parameter(
@@ -236,7 +243,7 @@ class SearchController extends Controller
      *     @OA\Parameter(
      *       name="sort",
      *       in="query",
-     *       @OA\Schema(ref="#/components/schemas/manga search query sort")
+     *       @OA\Schema(ref="#/components/schemas/search query sort")
      *     ),
      * 
      *     @OA\Parameter(
@@ -379,7 +386,7 @@ class SearchController extends Controller
      *     @OA\Parameter(
      *       name="sort",
      *       in="query",
-     *       @OA\Schema(ref="#/components/schemas/characters search query sort")
+     *       @OA\Schema(ref="#/components/schemas/search query sort")
      *     ),
      * 
      *     @OA\Parameter(

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -316,6 +316,30 @@ class SearchController extends Controller
      *     @OA\Parameter(ref="#/components/parameters/page"),
      *     @OA\Parameter(ref="#/components/parameters/limit"),
      * 
+     *     @OA\Parameter(
+     *       name="q",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="order_by",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/people search query orderby")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="sort",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/search query sort")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="letter",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
      *     @OA\Response(
      *         response="200",
      *         description="Returns search results for people",

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -470,7 +470,40 @@ class SearchController extends Controller
      *     path="/users",
      *     operationId="getUsersSearch",
      *     tags={"users"},
+     * 
+     *     @OA\Parameter(ref="#/components/parameters/page"),
+     *     @OA\Parameter(ref="#/components/parameters/limit"),
      *
+     *     @OA\Parameter(
+     *       name="q",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="gender",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/users search query gender")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="location",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="maxAge",
+     *       in="query",
+     *       @OA\Schema(type="intager")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="minAge",
+     *       in="query",
+     *       @OA\Schema(type="intager")
+     *     ),
+     * 
      *     @OA\Response(
      *         response="200",
      *         description="Returns search results for users",

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -50,6 +50,72 @@ class SearchController extends Controller
      *     path="/anime",
      *     operationId="getAnimeSearch",
      *     tags={"anime"},
+     * 
+     *     @OA\Parameter(
+     *       name="q",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="type",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/anime search query type")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="score",
+     *       in="query",
+     *       @OA\Schema(type="number")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="status",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/anime search query status")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="rating",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/anime search query rating")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="sfw",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="genres",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="order_by",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/anime search query orderby")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="sort",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/anime search query sort")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="letter",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="producer",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
      *
      *     @OA\Response(
      *         response="200",

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -658,6 +658,42 @@ class SearchController extends Controller
      *     @OA\Parameter(ref="#/components/parameters/page"),
      *     @OA\Parameter(ref="#/components/parameters/limit"),
      * 
+     *     @OA\Parameter(
+     *       name="q",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="type",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/club search query type")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="category",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/club search query category")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="order_by",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/club search query orderby")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="sort",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/search query sort")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="letter",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
      *     @OA\Response(
      *         response="200",
      *         description="Returns search results for clubs",

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -46,10 +46,26 @@ class SearchController extends Controller
     const MAX_RESULTS_PER_PAGE = 25;
 
     /**
+     *  @OA\Parameter(
+     *    name="page",
+     *    in="query",
+     *    @OA\Schema(type="number")
+     *  ),
+     *  @OA\Parameter(
+     *    name="limit",
+     *    in="query",
+     *    @OA\Schema(type="number")
+     *  ),
+     */
+
+    /**
      *  @OA\Get(
      *     path="/anime",
      *     operationId="getAnimeSearch",
      *     tags={"anime"},
+     * 
+     *     @OA\Parameter(ref="#/components/parameters/page"),
+     *     @OA\Parameter(ref="#/components/parameters/limit"),
      * 
      *     @OA\Parameter(
      *       name="q",
@@ -172,6 +188,9 @@ class SearchController extends Controller
      *     operationId="getMangaSearch",
      *     tags={"manga"},
      * 
+     *     @OA\Parameter(ref="#/components/parameters/page"),
+     *     @OA\Parameter(ref="#/components/parameters/limit"),
+     * 
      *     @OA\Parameter(
      *       name="q",
      *       in="query",
@@ -287,6 +306,9 @@ class SearchController extends Controller
      *     operationId="getPeopleSearch",
      *     tags={"people"},
      *
+     *     @OA\Parameter(ref="#/components/parameters/page"),
+     *     @OA\Parameter(ref="#/components/parameters/limit"),
+     * 
      *     @OA\Response(
      *         response="200",
      *         description="Returns search results for people",
@@ -339,6 +361,9 @@ class SearchController extends Controller
      *     operationId="getCharactersSearch",
      *     tags={"characters"},
      *
+     *     @OA\Parameter(ref="#/components/parameters/page"),
+     *     @OA\Parameter(ref="#/components/parameters/limit"),
+     * 
      *     @OA\Response(
      *         response="200",
      *         description="Returns search results for characters",
@@ -599,6 +624,9 @@ class SearchController extends Controller
      *     operationId="getClubsSearch",
      *     tags={"clubs"},
      *
+     *     @OA\Parameter(ref="#/components/parameters/page"),
+     *     @OA\Parameter(ref="#/components/parameters/limit"),
+     * 
      *     @OA\Response(
      *         response="200",
      *         description="Returns search results for clubs",

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -171,6 +171,66 @@ class SearchController extends Controller
      *     path="/manga",
      *     operationId="getMangaSearch",
      *     tags={"manga"},
+     * 
+     *     @OA\Parameter(
+     *       name="q",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="type",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/manga search query type")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="score",
+     *       in="query",
+     *       @OA\Schema(type="number")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="status",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/manga search query status")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="sfw",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="genres",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="order_by",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/manga search query orderby")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="sort",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/manga search query sort")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="letter",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="magazine",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
      *
      *     @OA\Response(
      *         response="200",

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -364,6 +364,30 @@ class SearchController extends Controller
      *     @OA\Parameter(ref="#/components/parameters/page"),
      *     @OA\Parameter(ref="#/components/parameters/limit"),
      * 
+     *     @OA\Parameter(
+     *       name="q",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="order_by",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/characters search query orderby")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="sort",
+     *       in="query",
+     *       @OA\Schema(ref="#/components/schemas/characters search query sort")
+     *     ),
+     * 
+     *     @OA\Parameter(
+     *       name="letter",
+     *       in="query",
+     *       @OA\Schema(type="string")
+     *     ),
+     * 
      *     @OA\Response(
      *         response="200",
      *         description="Returns search results for characters",

--- a/app/Http/QueryBuilder/SearchQueryBuilderAnime.php
+++ b/app/Http/QueryBuilder/SearchQueryBuilderAnime.php
@@ -271,13 +271,6 @@ class SearchQueryBuilderAnime implements SearchQueryBuilderInterface
     /**
      * @param string|null $sort
      * @return string|null
-     * 
-     * @OA\Schema(
-     *   schema="anime search query sort",
-     *   description="Anime Search Query Sort",
-     *   type="string",
-     *   enum={"desc","asc"}
-     * )
      */
     public static function mapSort(?string $sort = null) : ?string
     {

--- a/app/Http/QueryBuilder/SearchQueryBuilderAnime.php
+++ b/app/Http/QueryBuilder/SearchQueryBuilderAnime.php
@@ -20,7 +20,12 @@ class SearchQueryBuilderAnime implements SearchQueryBuilderInterface
     const MAX_RESULTS_PER_PAGE = 25;
 
     /**
-     *
+     * @OA\Schema(
+     *   schema="anime search query type",
+     *   description="Anime Search Query Type",
+     *   type="string",
+     *   enum={"tv","movie","ova","special","ona","music"}
+     * )
      */
     const MAP_TYPES = [
         'tv' => 'TV',
@@ -32,7 +37,12 @@ class SearchQueryBuilderAnime implements SearchQueryBuilderInterface
     ];
 
     /**
-     *
+     * @OA\Schema(
+     *   schema="anime search query status",
+     *   description="Anime Search Query Status",
+     *   type="string",
+     *   enum={"airing","complete","upcoming"}
+     * )
      */
     const MAP_STATUS = [
         'airing' => 'Currently Airing',
@@ -41,7 +51,12 @@ class SearchQueryBuilderAnime implements SearchQueryBuilderInterface
     ];
 
     /**
-     *
+     * @OA\Schema(
+     *   schema="anime search query rating",
+     *   description="Anime Search Query Rating",
+     *   type="string",
+     *   enum={"g","pg","pg13","r17","r","rx"}
+     * )
      */
     const MAP_RATING = [
         'g' => 'G - All Ages',
@@ -53,7 +68,12 @@ class SearchQueryBuilderAnime implements SearchQueryBuilderInterface
     ];
 
     /**
-     *
+     * @OA\Schema(
+     *   schema="anime search query orderby",
+     *   description="Anime Search Query OrderBy",
+     *   type="string",
+     *   enum={"mal_id", "title", "aired.from", "aired.to", "episodes", "score", "scored_by", "rank", "popularity", "members", "favorites" }
+     * )
      */
     const ORDER_BY = [
         'mal_id', 'title', 'aired.from', 'aired.to', 'episodes', 'score', 'scored_by', 'rank', 'popularity', 'members', 'favorites'
@@ -251,6 +271,13 @@ class SearchQueryBuilderAnime implements SearchQueryBuilderInterface
     /**
      * @param string|null $sort
      * @return string|null
+     * 
+     * @OA\Schema(
+     *   schema="anime search query sort",
+     *   description="Anime Search Query Sort",
+     *   type="string",
+     *   enum={"desc","asc"}
+     * )
      */
     public static function mapSort(?string $sort = null) : ?string
     {

--- a/app/Http/QueryBuilder/SearchQueryBuilderCharacter.php
+++ b/app/Http/QueryBuilder/SearchQueryBuilderCharacter.php
@@ -12,6 +12,14 @@ class SearchQueryBuilderCharacter implements SearchQueryBuilderInterface
 
     const MAX_RESULTS_PER_PAGE = 25;
 
+    /**
+     * @OA\Schema(
+     *   schema="characters search query orderby",
+     *   description="Characters Search Query OrderBy",
+     *   type="string",
+     *   enum={"mal_id", "name","member_favorites"}
+     * )
+     */
     const ORDER_BY = [
         'mal_id', 'name', 'member_favorites'
     ];
@@ -50,6 +58,14 @@ class SearchQueryBuilderCharacter implements SearchQueryBuilderInterface
         return $results;
     }
 
+    /**
+      * @OA\Schema(
+      *   schema="characters search query sort",
+      *   description="Characters Search Query Sort",
+      *   type="string",
+      *   enum={"desc","asc"}
+      * )
+      */
     public static function mapSort(?string $sort = null) : ?string
     {
         $sort = strtolower($sort);

--- a/app/Http/QueryBuilder/SearchQueryBuilderCharacter.php
+++ b/app/Http/QueryBuilder/SearchQueryBuilderCharacter.php
@@ -58,14 +58,6 @@ class SearchQueryBuilderCharacter implements SearchQueryBuilderInterface
         return $results;
     }
 
-    /**
-      * @OA\Schema(
-      *   schema="characters search query sort",
-      *   description="Characters Search Query Sort",
-      *   type="string",
-      *   enum={"desc","asc"}
-      * )
-      */
     public static function mapSort(?string $sort = null) : ?string
     {
         $sort = strtolower($sort);

--- a/app/Http/QueryBuilder/SearchQueryBuilderClub.php
+++ b/app/Http/QueryBuilder/SearchQueryBuilderClub.php
@@ -20,7 +20,12 @@ class SearchQueryBuilderClub implements SearchQueryBuilderInterface
     const MAX_RESULTS_PER_PAGE = 25;
 
     /**
-     *
+     * @OA\Schema(
+     *   schema="club search query type",
+     *   description="Club Search Query Type",
+     *   type="string",
+     *   enum={"public","private","secret"}
+     * )
      */
     const MAP_TYPES = [
         'public' => 'public',
@@ -29,7 +34,16 @@ class SearchQueryBuilderClub implements SearchQueryBuilderInterface
     ];
 
     /**
-     *
+     * @OA\Schema(
+     *   schema="club search query category",
+     *   description="Club Search Query Category",
+     *   type="string",
+     *   enum={
+     *      "anime","manga","actors_and_artists","characters",
+     *      "cities_and_neighborhoods","companies","conventions","games",
+     *      "japan","music","other","schools"
+     *   }
+     * )
      */
     const MAP_CATEGORY = [
         'anime' => 'Anime',
@@ -47,7 +61,12 @@ class SearchQueryBuilderClub implements SearchQueryBuilderInterface
     ];
 
     /**
-     *
+     * @OA\Schema(
+     *   schema="club search query orderby",
+     *   description="Club Search Query OrderBy",
+     *   type="string",
+     *   enum={"mal_id","title","members_count","pictures_count","created"}
+     * )
      */
     const ORDER_BY = [
         'mal_id', 'title', 'members_count', 'pictures_count', 'created'

--- a/app/Http/QueryBuilder/SearchQueryBuilderManga.php
+++ b/app/Http/QueryBuilder/SearchQueryBuilderManga.php
@@ -206,14 +206,6 @@ class SearchQueryBuilderManga implements SearchQueryBuilderInterface
         return self::MAP_STATUS[$status] ?? null;
     }
 
-    /**
-      * @OA\Schema(
-      *   schema="manga search query sort",
-      *   description="Anime Search Query Sort",
-      *   type="string",
-      *   enum={"desc","asc"}
-      * )
-      */
     public static function mapSort(?string $sort = null) : ?string
     {
         if (!is_null($sort)) {

--- a/app/Http/QueryBuilder/SearchQueryBuilderManga.php
+++ b/app/Http/QueryBuilder/SearchQueryBuilderManga.php
@@ -12,6 +12,14 @@ class SearchQueryBuilderManga implements SearchQueryBuilderInterface
 
     const MAX_RESULTS_PER_PAGE = 25;
 
+    /**
+     * @OA\Schema(
+     *   schema="manga search query type",
+     *   description="Manga Search Query Type",
+     *   type="string",
+     *   enum={"manga","novel","oneshot","doujin","manhwa","manhua"}
+     * )
+     */
     const MAP_TYPES = [
         'manga' => 'Manga',
         'novel' => 'Novel',
@@ -21,6 +29,14 @@ class SearchQueryBuilderManga implements SearchQueryBuilderInterface
         'manhua' => 'Manhua'
     ];
 
+    /**
+     * @OA\Schema(
+     *   schema="manga search query status",
+     *   description="Manga Search Query Status",
+     *   type="string",
+     *   enum={"airing","complete","hiatus","discontinued","upcoming"}
+     * )
+     */
     const MAP_STATUS = [
         'airing' => 'Publishing',
         'complete' => 'Finished',
@@ -29,6 +45,14 @@ class SearchQueryBuilderManga implements SearchQueryBuilderInterface
         'upcoming' => 'Not yet published'
     ];
 
+    /**
+     * @OA\Schema(
+     *   schema="manga search query orderby",
+     *   description="Manga Search Query OrderBy",
+     *   type="string",
+     *   enum={"mal_id", "title", "published.from", "published.to", "chapters", "volumes", "score", "scored_by", "rank", "popularity", "members", "favorites"}
+     * )
+     */
     const ORDER_BY = [
         'mal_id', 'title', 'published.from', 'published.to', 'chapters', 'volumes', 'score', 'scored_by', 'rank', 'popularity', 'members', 'favorites'
     ];
@@ -182,6 +206,14 @@ class SearchQueryBuilderManga implements SearchQueryBuilderInterface
         return self::MAP_STATUS[$status] ?? null;
     }
 
+    /**
+      * @OA\Schema(
+      *   schema="manga search query sort",
+      *   description="Anime Search Query Sort",
+      *   type="string",
+      *   enum={"desc","asc"}
+      * )
+      */
     public static function mapSort(?string $sort = null) : ?string
     {
         if (!is_null($sort)) {

--- a/app/Http/QueryBuilder/SearchQueryBuilderPeople.php
+++ b/app/Http/QueryBuilder/SearchQueryBuilderPeople.php
@@ -12,6 +12,14 @@ class SearchQueryBuilderPeople implements SearchQueryBuilderInterface
 
     const MAX_RESULTS_PER_PAGE = 25;
 
+    /**
+     * @OA\Schema(
+     *   schema="people search query orderby",
+     *   description="People Search Query OrderBy",
+     *   type="string",
+     *   enum={"mal_id","name","birthday","member_favorites"}
+     * )
+     */
     const ORDER_BY = [
         'mal_id', 'name', 'birthday', 'member_favorites'
     ];

--- a/app/Http/QueryBuilder/SearchQueryBuilderUsers.php
+++ b/app/Http/QueryBuilder/SearchQueryBuilderUsers.php
@@ -14,6 +14,14 @@ class SearchQueryBuilderUsers
 
     const MAX_RESULTS_PER_PAGE = 25;
 
+    /**
+     * @OA\Schema(
+     *   schema="users search query gender",
+     *   description="Users Search Query Gender",
+     *   type="string",
+     *   enum={"any","male","female","nonbinary"}
+     * )
+     */
     private const MAP_GENDERS = [
         'any' => JikanConstants::SEARCH_USER_GENDER_ANY,
         'male' => JikanConstants::SEARCH_USER_GENDER_MALE,

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -813,6 +813,69 @@
                 }
             }
         },
+        "/people/{id}/anime": {
+            "get": {
+                "tags": [
+                    "people"
+                ],
+                "operationId": "getPersonAnime",
+                "responses": {
+                    "200": {
+                        "description": "Returns person's anime staff positions",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error: Bad request. When required parameters were not supplied."
+                    }
+                }
+            }
+        },
+        "/people/{id}/voices": {
+            "get": {
+                "tags": [
+                    "people"
+                ],
+                "operationId": "getPersonVoices",
+                "responses": {
+                    "200": {
+                        "description": "Returns person's voice acting roles",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error: Bad request. When required parameters were not supplied."
+                    }
+                }
+            }
+        },
+        "/people/{id}/manga": {
+            "get": {
+                "tags": [
+                    "people"
+                ],
+                "operationId": "getPersonManga",
+                "responses": {
+                    "200": {
+                        "description": "Returns person's published manga",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error: Bad request. When required parameters were not supplied."
+                    }
+                }
+            }
+        },
         "/people/{id}/pictures": {
             "get": {
                 "tags": [
@@ -1071,6 +1134,91 @@
                     "anime"
                 ],
                 "operationId": "getAnimeSearch",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/limit"
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/anime search query type"
+                        }
+                    },
+                    {
+                        "name": "score",
+                        "in": "query",
+                        "schema": {
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/anime search query status"
+                        }
+                    },
+                    {
+                        "name": "rating",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/anime search query rating"
+                        }
+                    },
+                    {
+                        "name": "sfw",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "genres",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "order_by",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/anime search query orderby"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/search query sort"
+                        }
+                    },
+                    {
+                        "name": "letter",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "producer",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Returns search results for anime",
@@ -1094,6 +1242,84 @@
                     "manga"
                 ],
                 "operationId": "getMangaSearch",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/limit"
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/manga search query type"
+                        }
+                    },
+                    {
+                        "name": "score",
+                        "in": "query",
+                        "schema": {
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/manga search query status"
+                        }
+                    },
+                    {
+                        "name": "sfw",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "genres",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "order_by",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/manga search query orderby"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/search query sort"
+                        }
+                    },
+                    {
+                        "name": "letter",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "magazine",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Returns search results for manga",
@@ -1117,6 +1343,42 @@
                     "people"
                 ],
                 "operationId": "getPeopleSearch",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/limit"
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "order_by",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/people search query orderby"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/search query sort"
+                        }
+                    },
+                    {
+                        "name": "letter",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Returns search results for people",
@@ -1138,6 +1400,42 @@
                     "characters"
                 ],
                 "operationId": "getCharactersSearch",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/limit"
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "order_by",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/characters search query orderby"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/search query sort"
+                        }
+                    },
+                    {
+                        "name": "letter",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Returns search results for characters",
@@ -1159,6 +1457,49 @@
                     "users"
                 ],
                 "operationId": "getUsersSearch",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/limit"
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "gender",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/users search query gender"
+                        }
+                    },
+                    {
+                        "name": "location",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "maxAge",
+                        "in": "query",
+                        "schema": {
+                            "type": "intager"
+                        }
+                    },
+                    {
+                        "name": "minAge",
+                        "in": "query",
+                        "schema": {
+                            "type": "intager"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Returns search results for users",
@@ -1201,6 +1542,56 @@
                     "clubs"
                 ],
                 "operationId": "getClubsSearch",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/limit"
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/club search query type"
+                        }
+                    },
+                    {
+                        "name": "category",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/club search query category"
+                        }
+                    },
+                    {
+                        "name": "order_by",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/club search query orderby"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/search query sort"
+                        }
+                    },
+                    {
+                        "name": "letter",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Returns search results for clubs",
@@ -1911,6 +2302,14 @@
                 },
                 "type": "object"
             },
+            "search query sort": {
+                "description": "Characters Search Query Sort",
+                "type": "string",
+                "enum": [
+                    "desc",
+                    "asc"
+                ]
+            },
             "user collection": {
                 "description": "User Results",
                 "allOf": [
@@ -1927,7 +2326,7 @@
                     }
                 ]
             },
-            "user by id": {
+            "users": {
                 "description": "User Meta By ID",
                 "properties": {
                     "data": {
@@ -2252,6 +2651,164 @@
                         },
                         "type": "object"
                     }
+                ]
+            },
+            "anime search query type": {
+                "description": "Anime Search Query Type",
+                "type": "string",
+                "enum": [
+                    "tv",
+                    "movie",
+                    "ova",
+                    "special",
+                    "ona",
+                    "music"
+                ]
+            },
+            "anime search query status": {
+                "description": "Anime Search Query Status",
+                "type": "string",
+                "enum": [
+                    "airing",
+                    "complete",
+                    "upcoming"
+                ]
+            },
+            "anime search query rating": {
+                "description": "Anime Search Query Rating",
+                "type": "string",
+                "enum": [
+                    "g",
+                    "pg",
+                    "pg13",
+                    "r17",
+                    "r",
+                    "rx"
+                ]
+            },
+            "anime search query orderby": {
+                "description": "Anime Search Query OrderBy",
+                "type": "string",
+                "enum": [
+                    "mal_id",
+                    "title",
+                    "aired.from",
+                    "aired.to",
+                    "episodes",
+                    "score",
+                    "scored_by",
+                    "rank",
+                    "popularity",
+                    "members",
+                    "favorites"
+                ]
+            },
+            "characters search query orderby": {
+                "description": "Characters Search Query OrderBy",
+                "type": "string",
+                "enum": [
+                    "mal_id",
+                    "name",
+                    "member_favorites"
+                ]
+            },
+            "club search query type": {
+                "description": "Club Search Query Type",
+                "type": "string",
+                "enum": [
+                    "public",
+                    "private",
+                    "secret"
+                ]
+            },
+            "club search query category": {
+                "description": "Club Search Query Category",
+                "type": "string",
+                "enum": [
+                    "anime",
+                    "manga",
+                    "actors_and_artists",
+                    "characters",
+                    "cities_and_neighborhoods",
+                    "companies",
+                    "conventions",
+                    "games",
+                    "japan",
+                    "music",
+                    "other",
+                    "schools"
+                ]
+            },
+            "club search query orderby": {
+                "description": "Club Search Query OrderBy",
+                "type": "string",
+                "enum": [
+                    "mal_id",
+                    "title",
+                    "members_count",
+                    "pictures_count",
+                    "created"
+                ]
+            },
+            "manga search query type": {
+                "description": "Manga Search Query Type",
+                "type": "string",
+                "enum": [
+                    "manga",
+                    "novel",
+                    "oneshot",
+                    "doujin",
+                    "manhwa",
+                    "manhua"
+                ]
+            },
+            "manga search query status": {
+                "description": "Manga Search Query Status",
+                "type": "string",
+                "enum": [
+                    "airing",
+                    "complete",
+                    "hiatus",
+                    "discontinued",
+                    "upcoming"
+                ]
+            },
+            "manga search query orderby": {
+                "description": "Manga Search Query OrderBy",
+                "type": "string",
+                "enum": [
+                    "mal_id",
+                    "title",
+                    "published.from",
+                    "published.to",
+                    "chapters",
+                    "volumes",
+                    "score",
+                    "scored_by",
+                    "rank",
+                    "popularity",
+                    "members",
+                    "favorites"
+                ]
+            },
+            "people search query orderby": {
+                "description": "People Search Query OrderBy",
+                "type": "string",
+                "enum": [
+                    "mal_id",
+                    "name",
+                    "birthday",
+                    "member_favorites"
+                ]
+            },
+            "users search query gender": {
+                "description": "Users Search Query Gender",
+                "type": "string",
+                "enum": [
+                    "any",
+                    "male",
+                    "female",
+                    "nonbinary"
                 ]
             },
             "anime characters": {
@@ -4213,7 +4770,7 @@
                 },
                 "type": "object"
             },
-            "user": {
+            "users2": {
                 "properties": {
                     "data": {
                         "description": "Transform the resource into an array.",
@@ -4665,6 +5222,22 @@
                     }
                 },
                 "type": "object"
+            }
+        },
+        "parameters": {
+            "page": {
+                "name": "page",
+                "in": "query",
+                "schema": {
+                    "type": "number"
+                }
+            },
+            "limit": {
+                "name": "limit",
+                "in": "query",
+                "schema": {
+                    "type": "number"
+                }
             }
         }
     },


### PR DESCRIPTION
Adds query parameters for `/anime`,`/manga`,`/characters`,`/clubs`,`/people`,`/users`.

#### Worth to mention:
- https://github.com/jikan-me/jikan-rest/commit/7b42adf74db8119b7e0426b83314bb7f9cba2fc4 caused name duplication so `swagger-lume:generate` is failing. I did generate `api-docs.json` anyway by concatenating number to schema name, but it should be fixed properly sooner or later
