### PR TITLE
[Feature] User's last updates

### DIFF
--- a/app/Http/Resources/V4/ProfileLastUpdatesResource.php
+++ b/app/Http/Resources/V4/ProfileLastUpdatesResource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Resources\V4;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProfileLastUpdatesResource extends JsonResource
+{
+
+    public function toArray($request)
+    {
+        return $this->userLastUpdates;
+    }
+}

--- a/routes/web.v4.php
+++ b/routes/web.v4.php
@@ -292,6 +292,10 @@ $router->group(
                     'uses' => 'UserController@favorites'
                 ]);
 
+                $router->get('/userupdates', [
+                    'uses' => 'UserController@userupdates'
+                ]);
+
                 $router->get('/about', [
                     'uses' => 'UserController@about'
                 ]);


### PR DESCRIPTION
#### Summary
Expose user's last anime/manga updates (jikan-me/jikan#339) from profile to `/users/Username/userupdates` endpoint.

At the moment requesting to `/users/N0D4N/userupdates` returns nothing, no exceptions are thrown, simply white page.
I'll appreciate any hints/help on what i should change fix.