### PR TITLE
Fix get*ById wrapper info in OpenAPI schema

### DIFF
--- a/app/Http/Controllers/V4DB/AnimeController.php
+++ b/app/Http/Controllers/V4DB/AnimeController.php
@@ -154,10 +154,10 @@ class AnimeController extends Controller
      *         response="200",
      *         description="Returns anime resource",
      *         @OA\JsonContent(
-     *              @OA\Property(
-     *                  property="data",
-     *                  ref="#/components/schemas/anime"
-     *              )
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/anime"
+     *             )
      *         )
      *     ),
      *     @OA\Response(
@@ -484,7 +484,10 @@ class AnimeController extends Controller
      *         response="200",
      *         description="Returns a single anime episode resource",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/anime_episode"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/anime_episode"
+     *             )
      *         )
      *     ),
      *     @OA\Response(

--- a/app/Http/Controllers/V4DB/CharacterController.php
+++ b/app/Http/Controllers/V4DB/CharacterController.php
@@ -39,7 +39,10 @@ class CharacterController extends Controller
      *         response="200",
      *         description="Returns complete character resource data",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/character_full"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/character_full"
+     *             )
      *         )
      *     ),
      *     @OA\Response(
@@ -123,7 +126,10 @@ class CharacterController extends Controller
      *         response="200",
      *         description="Returns character resource",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/character"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/character"
+     *             )
      *         )
      *     ),
      *     @OA\Response(

--- a/app/Http/Controllers/V4DB/ClubController.php
+++ b/app/Http/Controllers/V4DB/ClubController.php
@@ -35,7 +35,10 @@ class ClubController extends Controller
      *         response="200",
      *         description="Returns Club Resource",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/club"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/club"
+     *             )
      *         )
      *     ),
      *     @OA\Response(

--- a/app/Http/Controllers/V4DB/MangaController.php
+++ b/app/Http/Controllers/V4DB/MangaController.php
@@ -64,9 +64,12 @@ class MangaController extends Controller
      *
      *     @OA\Response(
      *         response="200",
-     *         description="Returns complete anime resource data",
+     *         description="Returns complete manga resource data",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/manga_full"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/manga_full"
+     *             )
      *         )
      *     ),
      *
@@ -152,7 +155,10 @@ class MangaController extends Controller
      *         response="200",
      *         description="Returns pictures related to the entry",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/manga"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/manga"
+     *             )
      *         )
      *     ),
      *

--- a/app/Http/Controllers/V4DB/PersonController.php
+++ b/app/Http/Controllers/V4DB/PersonController.php
@@ -38,7 +38,10 @@ class PersonController extends Controller
      *         response="200",
      *         description="Returns complete character resource data",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/person_full"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/person_full"
+     *             )
      *         )
      *     ),
      *
@@ -123,7 +126,10 @@ class PersonController extends Controller
      *         response="200",
      *         description="Returns pictures related to the entry",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/person"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/person"
+     *             )
      *         )
      *     ),
      *

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -671,16 +671,26 @@ class SearchController extends Controller
 
     /**
      *  @OA\Get(
-     *     path="/users/userbyid",
+     *     path="/users/userbyid/{id}",
      *     operationId="getUserById",
      *     tags={"users"},
+     *
+     *     @OA\Parameter(
+     *       name="id",
+     *       in="path",
+     *       required=true,
+     *       @OA\Schema(type="integer")
+     *     ),
      *
      *     @OA\Response(
      *         response="200",
      *         description="Returns username by ID search",
-     *          @OA\JsonContent(
-     *               ref="#/components/schemas/user_by_id"
-     *          )
+     *         @OA\JsonContent(
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/user_by_id"
+     *             )
+     *         )
      *     ),
      *     @OA\Response(
      *         response="400",

--- a/app/Http/Controllers/V4DB/UserController.php
+++ b/app/Http/Controllers/V4DB/UserController.php
@@ -51,7 +51,10 @@ class UserController extends Controller
      *         response="200",
      *         description="Returns complete user resource data",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/user_profile_full"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/user_profile_full"
+     *             )
      *         )
      *     ),
      *     @OA\Response(
@@ -134,7 +137,10 @@ class UserController extends Controller
      *         response="200",
      *         description="Returns user profile",
      *         @OA\JsonContent(
-     *              ref="#/components/schemas/user_profile"
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/user_profile"
+     *             )
      *         )
      *     ),
      *     @OA\Response(

--- a/app/Http/Resources/V4/AnimeEpisodeResource.php
+++ b/app/Http/Resources/V4/AnimeEpisodeResource.php
@@ -7,70 +7,66 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class AnimeEpisodeResource extends JsonResource
 {
     /**
-     *  @OA\Schema(
-     *      schema="anime_episode",
-     *      description="Anime Episode Resource",
+     * @OA\Schema(
+     *     schema="anime_episode",
+     *     description="Anime Episode Resource",
      *
      *     @OA\Property(
-     *          property="data",
-     *          type="object",
-     *          @OA\Property(
-     *              property="mal_id",
-     *              type="integer",
-     *              description="MyAnimeList ID"
-     *          ),
-     *          @OA\Property(
-     *              property="url",
-     *              type="string",
-     *              description="MyAnimeList URL"
-     *          ),
-     *          @OA\Property(
-     *              property="title",
-     *              type="string",
-     *              description="Title"
-     *          ),
-     *          @OA\Property(
-     *              property="title_japanese",
-     *              type="string",
-     *              description="Title Japanese",
-     *              nullable=true
-     *          ),
-     *          @OA\Property(
-     *              property="title_romanji",
-     *              type="string",
-     *              description="title_romanji",
-     *              nullable=true
-     *          ),
-     *          @OA\Property(
-     *              property="duration",
-     *              type="integer",
-     *              description="Episode duration in seconds",
-     *              nullable=true
-     *          ),
-     *          @OA\Property(
-     *              property="aired",
-     *              type="string",
-     *              description="Aired Date ISO8601",
-     *              nullable=true
-     *          ),
-     *          @OA\Property(
-     *              property="filler",
-     *              type="boolean",
-     *              description="Filler episode"
-     *          ),
-     *          @OA\Property(
-     *              property="recap",
-     *              type="boolean",
-     *              description="Recap episode"
-     *          ),
-     *          @OA\Property(
-     *              property="synopsis",
-     *              type="string",
-     *              description="Episode Synopsis",
-     *              nullable=true
-     *          ),
+     *         property="mal_id",
+     *         type="integer",
+     *         description="MyAnimeList ID"
      *     ),
-     *  )
+     *     @OA\Property(
+     *         property="url",
+     *         type="string",
+     *         description="MyAnimeList URL"
+     *     ),
+     *     @OA\Property(
+     *         property="title",
+     *         type="string",
+     *         description="Title"
+     *     ),
+     *     @OA\Property(
+     *         property="title_japanese",
+     *         type="string",
+     *         description="Title Japanese",
+     *         nullable=true
+     *     ),
+     *     @OA\Property(
+     *         property="title_romanji",
+     *         type="string",
+     *         description="title_romanji",
+     *         nullable=true
+     *     ),
+     *     @OA\Property(
+     *         property="duration",
+     *         type="integer",
+     *         description="Episode duration in seconds",
+     *         nullable=true
+     *     ),
+     *     @OA\Property(
+     *         property="aired",
+     *         type="string",
+     *         description="Aired Date ISO8601",
+     *         nullable=true
+     *     ),
+     *     @OA\Property(
+     *         property="filler",
+     *         type="boolean",
+     *         description="Filler episode"
+     *     ),
+     *     @OA\Property(
+     *         property="recap",
+     *         type="boolean",
+     *         description="Recap episode"
+     *     ),
+     *     @OA\Property(
+     *         property="synopsis",
+     *         type="string",
+     *         description="Episode Synopsis",
+     *         nullable=true
+     *     ),
+     * )
      */
 
     /**

--- a/app/Http/Resources/V4/ClubResource.php
+++ b/app/Http/Resources/V4/ClubResource.php
@@ -16,52 +16,47 @@ class ClubResource extends JsonResource
      *     schema="club",
      *     description="Club Resource",
      *
-     *      @OA\Property(
-     *          property="data",
-     *          type="object",
-     *
-     *          @OA\Property(
-     *              property="mal_id",
-     *              type="integer",
-     *              description="MyAnimeList ID"
-     *          ),
-     *          @OA\Property(
-     *              property="name",
-     *              type="string",
-     *              description="Club name"
-     *          ),
-     *          @OA\Property(
-     *              property="url",
-     *              type="string",
-     *              description="Club URL"
-     *          ),
-     *          @OA\Property(
-     *              property="images",
-     *              type="object",
-     *              ref="#/components/schemas/common_images",
-     *          ),
-     *          @OA\Property(
-     *              property="members",
-     *              type="integer",
-     *              description="Number of club members"
-     *          ),
-     *          @OA\Property(
-     *              property="category",
-     *              type="string",
-     *              description="Club Category",
-     *              enum={"actors & artists", "anime", "characters", "cities & neighborhoods", "companies", "conventions", "games", "japan", "manga", "music", "others", "schools"}
-     *          ),
-     *          @OA\Property(
-     *              property="created",
-     *              type="string",
-     *              description="Date Created ISO8601"
-     *          ),
-     *          @OA\Property(
-     *              property="access",
-     *              type="string",
-     *              description="Club access",
-     *              enum={"public", "private", "secret"}
-     *          ),
+     *     @OA\Property(
+     *         property="mal_id",
+     *         type="integer",
+     *         description="MyAnimeList ID"
+     *     ),
+     *     @OA\Property(
+     *         property="name",
+     *         type="string",
+     *         description="Club name"
+     *     ),
+     *     @OA\Property(
+     *         property="url",
+     *         type="string",
+     *         description="Club URL"
+     *     ),
+     *     @OA\Property(
+     *         property="images",
+     *         type="object",
+     *         ref="#/components/schemas/common_images",
+     *     ),
+     *     @OA\Property(
+     *         property="members",
+     *         type="integer",
+     *         description="Number of club members"
+     *     ),
+     *     @OA\Property(
+     *         property="category",
+     *         type="string",
+     *         description="Club Category",
+     *         enum={"actors & artists", "anime", "characters", "cities & neighborhoods", "companies", "conventions", "games", "japan", "manga", "music", "others", "schools"}
+     *     ),
+     *     @OA\Property(
+     *         property="created",
+     *         type="string",
+     *         description="Date Created ISO8601"
+     *     ),
+     *     @OA\Property(
+     *         property="access",
+     *         type="string",
+     *         description="Club access",
+     *         enum={"public", "private", "secret"}
      *     ),
      * ),
      */

--- a/app/Http/Resources/V4/CommonResource.php
+++ b/app/Http/Resources/V4/CommonResource.php
@@ -373,19 +373,14 @@ class CommonResource extends JsonResource
      *      description="User Meta By ID",
      *
      *      @OA\Property(
-     *           property="data",
-     *           type="object",
-     *
-     *           @OA\Property(
-     *               property="url",
-     *               type="string",
-     *               description="MyAnimeList URL"
-     *           ),
-     *           @OA\Property(
-     *               property="username",
-     *               type="string",
-     *               description="MyAnimeList Username"
-     *           ),
+     *          property="url",
+     *          type="string",
+     *          description="MyAnimeList URL"
+     *      ),
+     *      @OA\Property(
+     *          property="username",
+     *          type="string",
+     *          description="MyAnimeList Username"
      *      ),
      *  ),
      *

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -229,7 +229,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/anime_episode"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/anime_episode"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -686,7 +691,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/character_full"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/character_full"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -719,7 +729,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/character"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/character"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -884,7 +899,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/club"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/club"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -1114,11 +1134,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Returns complete anime resource data",
+                        "description": "Returns complete manga resource data",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/manga_full"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/manga_full"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -1151,7 +1176,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/manga"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/manga"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -1578,7 +1608,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/person_full"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/person_full"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -1611,7 +1646,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/person"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/person"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -2588,19 +2628,34 @@
                 }
             }
         },
-        "/users/userbyid": {
+        "/users/userbyid/{id}": {
             "get": {
                 "tags": [
                     "users"
                 ],
                 "operationId": "getUserById",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Returns username by ID search",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/user_by_id"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/user_by_id"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -3093,7 +3148,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/user_profile_full"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/user_profile_full"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -3126,7 +3186,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/user_profile"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/user_profile"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -4409,55 +4474,50 @@
             "anime_episode": {
                 "description": "Anime Episode Resource",
                 "properties": {
-                    "data": {
-                        "properties": {
-                            "mal_id": {
-                                "description": "MyAnimeList ID",
-                                "type": "integer"
-                            },
-                            "url": {
-                                "description": "MyAnimeList URL",
-                                "type": "string"
-                            },
-                            "title": {
-                                "description": "Title",
-                                "type": "string"
-                            },
-                            "title_japanese": {
-                                "nullable": true,
-                                "description": "Title Japanese",
-                                "type": "string"
-                            },
-                            "title_romanji": {
-                                "nullable": true,
-                                "description": "title_romanji",
-                                "type": "string"
-                            },
-                            "duration": {
-                                "nullable": true,
-                                "description": "Episode duration in seconds",
-                                "type": "integer"
-                            },
-                            "aired": {
-                                "nullable": true,
-                                "description": "Aired Date ISO8601",
-                                "type": "string"
-                            },
-                            "filler": {
-                                "description": "Filler episode",
-                                "type": "boolean"
-                            },
-                            "recap": {
-                                "description": "Recap episode",
-                                "type": "boolean"
-                            },
-                            "synopsis": {
-                                "nullable": true,
-                                "description": "Episode Synopsis",
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
+                    "mal_id": {
+                        "description": "MyAnimeList ID",
+                        "type": "integer"
+                    },
+                    "url": {
+                        "description": "MyAnimeList URL",
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "Title",
+                        "type": "string"
+                    },
+                    "title_japanese": {
+                        "nullable": true,
+                        "description": "Title Japanese",
+                        "type": "string"
+                    },
+                    "title_romanji": {
+                        "nullable": true,
+                        "description": "title_romanji",
+                        "type": "string"
+                    },
+                    "duration": {
+                        "nullable": true,
+                        "description": "Episode duration in seconds",
+                        "type": "integer"
+                    },
+                    "aired": {
+                        "nullable": true,
+                        "description": "Aired Date ISO8601",
+                        "type": "string"
+                    },
+                    "filler": {
+                        "description": "Filler episode",
+                        "type": "boolean"
+                    },
+                    "recap": {
+                        "description": "Recap episode",
+                        "type": "boolean"
+                    },
+                    "synopsis": {
+                        "nullable": true,
+                        "description": "Episode Synopsis",
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -5373,60 +5433,55 @@
             "club": {
                 "description": "Club Resource",
                 "properties": {
-                    "data": {
-                        "properties": {
-                            "mal_id": {
-                                "description": "MyAnimeList ID",
-                                "type": "integer"
-                            },
-                            "name": {
-                                "description": "Club name",
-                                "type": "string"
-                            },
-                            "url": {
-                                "description": "Club URL",
-                                "type": "string"
-                            },
-                            "images": {
-                                "$ref": "#/components/schemas/common_images"
-                            },
-                            "members": {
-                                "description": "Number of club members",
-                                "type": "integer"
-                            },
-                            "category": {
-                                "description": "Club Category",
-                                "type": "string",
-                                "enum": [
-                                    "actors & artists",
-                                    "anime",
-                                    "characters",
-                                    "cities & neighborhoods",
-                                    "companies",
-                                    "conventions",
-                                    "games",
-                                    "japan",
-                                    "manga",
-                                    "music",
-                                    "others",
-                                    "schools"
-                                ]
-                            },
-                            "created": {
-                                "description": "Date Created ISO8601",
-                                "type": "string"
-                            },
-                            "access": {
-                                "description": "Club access",
-                                "type": "string",
-                                "enum": [
-                                    "public",
-                                    "private",
-                                    "secret"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                    "mal_id": {
+                        "description": "MyAnimeList ID",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "description": "Club name",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "Club URL",
+                        "type": "string"
+                    },
+                    "images": {
+                        "$ref": "#/components/schemas/common_images"
+                    },
+                    "members": {
+                        "description": "Number of club members",
+                        "type": "integer"
+                    },
+                    "category": {
+                        "description": "Club Category",
+                        "type": "string",
+                        "enum": [
+                            "actors & artists",
+                            "anime",
+                            "characters",
+                            "cities & neighborhoods",
+                            "companies",
+                            "conventions",
+                            "games",
+                            "japan",
+                            "manga",
+                            "music",
+                            "others",
+                            "schools"
+                        ]
+                    },
+                    "created": {
+                        "description": "Date Created ISO8601",
+                        "type": "string"
+                    },
+                    "access": {
+                        "description": "Club access",
+                        "type": "string",
+                        "enum": [
+                            "public",
+                            "private",
+                            "secret"
+                        ]
                     }
                 },
                 "type": "object"
@@ -5765,18 +5820,13 @@
             "user_by_id": {
                 "description": "User Meta By ID",
                 "properties": {
-                    "data": {
-                        "properties": {
-                            "url": {
-                                "description": "MyAnimeList URL",
-                                "type": "string"
-                            },
-                            "username": {
-                                "description": "MyAnimeList Username",
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
+                    "url": {
+                        "description": "MyAnimeList URL",
+                        "type": "string"
+                    },
+                    "username": {
+                        "description": "MyAnimeList Username",
+                        "type": "string"
                     }
                 },
                 "type": "object"


### PR DESCRIPTION
Fixes #232

OpenAPI schema is going to be important for generating clients. If the schema is incorrect then the generated client will create invalid code. This PR includes a major fix for OpenAPI schema.