### PR TITLE
Fix @OA\Schema reference in OpenAPI schema

### DIFF
--- a/app/Http/Controllers/V4DB/ScheduleController.php
+++ b/app/Http/Controllers/V4DB/ScheduleController.php
@@ -99,9 +99,8 @@ class ScheduleController extends Controller
      *                   type="array",
      *
      *                   @OA\Items(
-     *                       allOf={
-     *                           @OA\Schema(ref="#/components/schemas/anime"),
-     *                       }
+     *                       type="object",
+     *                       ref="#/components/schemas/anime",
      *                   )
      *              ),
      *          )

--- a/app/Http/Controllers/V4DB/SearchController.php
+++ b/app/Http/Controllers/V4DB/SearchController.php
@@ -607,31 +607,29 @@ class SearchController extends Controller
      *           @OA\Schema(ref="#/components/schemas/pagination"),
      *           @OA\Schema(
      *              @OA\Property(
-     *                   property="data",
-     *                   type="array",
+     *                  property="data",
+     *                  type="array",
      *
-     *                    @OA\Items(
-     *                        type="object",
-     *                        @OA\Schema(
-     *                            @OA\Property(
-     *                                property="url",
-     *                                type="string",
-     *                                description="MyAnimeList URL"
-     *                            ),
-     *                            @OA\Property(
-     *                                property="username",
-     *                                type="string",
-     *                                description="MyAnimeList Username"
-     *                            ),
-     *                            @OA\Property(
-     *                               ref="#/components/schemas/user_images"
-     *                            ),
-     *                            @OA\Property(
-     *                                property="last_online",
-     *                                type="string",
-     *                                description="Last Online Date ISO8601"
-     *                            ),
-     *                        ),
+     *                  @OA\Items(
+     *                      type="object",
+     *                      @OA\Property(
+     *                          property="url",
+     *                          type="string",
+     *                          description="MyAnimeList URL"
+     *                      ),
+     *                      @OA\Property(
+     *                          property="username",
+     *                          type="string",
+     *                          description="MyAnimeList Username"
+     *                      ),
+     *                      @OA\Property(
+     *                         ref="#/components/schemas/user_images"
+     *                      ),
+     *                      @OA\Property(
+     *                          property="last_online",
+     *                          type="string",
+     *                          description="Last Online Date ISO8601"
+     *                      ),
      *                  ),
      *              ),
      *          ),

--- a/app/Http/Resources/V4/MangaCollection.php
+++ b/app/Http/Resources/V4/MangaCollection.php
@@ -26,9 +26,8 @@ class MangaCollection extends ResourceCollection
      *                   type="array",
      *
      *                   @OA\Items(
-     *                       allOf={
-     *                           @OA\Schema(ref="#/components/schemas/manga"),
-     *                       }
+     *                       type="object",
+     *                       ref="#/components/schemas/manga",
      *                   )
      *              ),
      *          )

--- a/app/Http/Resources/V4/ProfileHistoryResource.php
+++ b/app/Http/Resources/V4/ProfileHistoryResource.php
@@ -21,7 +21,7 @@ class ProfileHistoryResource extends JsonResource
      *          type="array",
      *          @OA\Items(
      *              type="object",
-     *              @OA\Schema(ref="#/components/schemas/history"),
+     *              ref="#/components/schemas/history",
      *          ),
      *      ),
      *  ),

--- a/config/swagger-lume.php
+++ b/config/swagger-lume.php
@@ -200,7 +200,7 @@ return [
      */
     'constants' => [
         // 'SWAGGER_LUME_CONST_HOST' => env('SWAGGER_LUME_CONST_HOST', 'http://my-default-host.com'),
-        'API_DESCRIPTION' => <<<EOF
+        'API_DESCRIPTION' => str_replace("\r\n", "\n", <<<EOF
         [Jikan](https://jikan.moe) is an **Unofficial** MyAnimeList API.
         It scrapes the website to satisfy the need for a complete API - which MyAnimeList lacks.
         
@@ -304,6 +304,6 @@ return [
         By using the API, you are agreeing to Jikan's [terms of use](https://jikan.moe/terms) policy.
 
         [v3 Documentation](https://jikan.docs.apiary.io/) - [Wrappers/SDKs](https://github.com/jikan-me/jikan#wrappers) - [Report an issue](https://github.com/jikan-me/jikan-rest/issues/new) - [Host your own server](https://github.com/jikan-me/jikan-rest)
-        EOF,
+        EOF),
     ],
 ];

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "title": "Jikan API",
-        "description": "[Jikan](https://jikan.moe) is an **Unofficial** MyAnimeList API.\r\nIt scrapes the website to satisfy the need for a complete API - which MyAnimeList lacks.\r\n\r\n# Information\r\n\r\n⚡ Jikan is powered by it's awesome backers - 🙏 [Become a backer](https://www.patreon.com/jikan)\r\n\r\n## Rate Limiting\r\n\r\n| Duration | Requests |\r\n|----|----|\r\n| Monthly | **Unlimited** |\r\n| Per Minute | 60 requests |\r\n| Per Second | 3 requests |\r\n\r\n\r\n## JSON Notes\r\n- Any property (except arrays or objects) whose value does not exist or is undetermined, will be `null`.\r\n- Any array or object property whose value does not exist or is undetermined, will be empty.\r\n- Any `score` property whose value does not exist or is undetermined, will be `0`.\r\n- All dates and timestamps are returned in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format and in UTC timezone\r\n\r\n## Caching\r\nBy **CACHING**, we refer to the data parsed from MyAnimeList which is stored temporarily on our servers to provide better API performance.\r\n\r\nAll requests, by default are cached for **24 hours** except the following endpoints which have their own unique cache **Time To Live**. \r\n\r\n| Request | TTL |\r\n| ---- | ---- |\r\n| All (Default) | 24 hours |\r\n\r\n\r\nThe following response headers will detail cache information.\r\n\r\n| Header | Remarks |\r\n| ---- | ---- |\r\n| `Expires` | Cache expiry date |\r\n| `Last-Modified` | Cache set date |\r\n| `X-Request-Fingerprint` | Unique request fingerprint |\r\n\r\n\r\nNote: Caching headers will only be available on single resource requests and their child endpoints. e.g `/anime/1`, `/anime/1/relations`. \r\nThey won't be available on pages which perform queries, like /anime, or /top/anime, etc.\r\n\r\n## Allowed HTTP(s) requests\r\n\r\n**Jikan REST API does not provide authenticated requests for MyAnimeList.** This means you can not use it to update your anime/manga list.\r\nOnly GET requests are supported which return READ-ONLY data.\r\n\r\n## HTTP Responses\r\n\r\n| HTTP Status | Remarks |\r\n| ---- | ---- |\r\n| `200 - OK` | The request was successful |\r\n| `304 - Not Modified` | You have the latest data (Cache Validation response) |\r\n| `400 - Bad Request` | You've made an invalid request. Recheck documentation |\r\n| `404 - Not Found` | The resource was not found or MyAnimeList responded with a `404` |\r\n| `405 - Method Not Allowed` | Requested Method is not supported for resource. Only `GET` requests are allowed |\r\n| `429 - Too Many Request` | You are being rate limited by Jikan or MyAnimeList is rate-limiting our servers (specified in the error response) |\r\n| `500 - Internal Server Error` | Something is not working on our end. If you see an error response with a `report_url` URL, please click on it to open an auto-generated GitHub issue |\r\n| `503 - Service Unavailable` | The service has broke. |\r\n\r\n\r\n## JSON Error Response\r\n\r\n```json\r\n {\r\n     \"status\": 404,\r\n     \"type\": \"BadResponseException\",\r\n     \"message\": \"Resource does not exist\",\r\n     \"error\": \"Something Happened\",\r\n     \"report_url\": \"https://github.com...\"\r\n  }\r\n```\r\n\r\n| Property | Remarks |\r\n| ---- | ---- |\r\n| `status` | Returned HTTP Status Code |\r\n| `type` | Thrown Exception |\r\n| `message` | Human-readable error message |\r\n| `error` | Error response and trace from the API |\r\n| `report_url` | Clicking this would redirect you to a generated GitHub issue. ℹ It's only returned on a parser error. |\r\n\r\n\r\n## Cache Validation\r\n\r\n- All requests return a `ETag` header which is an MD5 hash of the response\r\n- You can use this hash to verify if there's new or updated content by suppliying it as the value for the `If-None-Match` in your next request header\r\n- You will get a HTTP `304 - Not Modified` response if the content has not changed\r\n- If the content has changed, you'll get a HTTP `200 - OK` response with the updated JSON response\r\n\r\n![Cache Validation](https://i.imgur.com/925ozVn.png 'Cache Validation')\r\n\r\n## Disclaimer\r\n\r\n- Jikan is not affiliated with MyAnimeList.net.\r\n- Jikan is a free, open-source API. Please use it responsibly.\r\n\r\n----\r\n\r\nBy using the API, you are agreeing to Jikan's [terms of use](https://jikan.moe/terms) policy.\r\n\r\n[v3 Documentation](https://jikan.docs.apiary.io/) - [Wrappers/SDKs](https://github.com/jikan-me/jikan#wrappers) - [Report an issue](https://github.com/jikan-me/jikan-rest/issues/new) - [Host your own server](https://github.com/jikan-me/jikan-rest)",
+        "description": "[Jikan](https://jikan.moe) is an **Unofficial** MyAnimeList API.\nIt scrapes the website to satisfy the need for a complete API - which MyAnimeList lacks.\n\n# Information\n\n⚡ Jikan is powered by it's awesome backers - 🙏 [Become a backer](https://www.patreon.com/jikan)\n\n## Rate Limiting\n\n| Duration | Requests |\n|----|----|\n| Monthly | **Unlimited** |\n| Per Minute | 60 requests |\n| Per Second | 3 requests |\n\n\n## JSON Notes\n- Any property (except arrays or objects) whose value does not exist or is undetermined, will be `null`.\n- Any array or object property whose value does not exist or is undetermined, will be empty.\n- Any `score` property whose value does not exist or is undetermined, will be `0`.\n- All dates and timestamps are returned in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format and in UTC timezone\n\n## Caching\nBy **CACHING**, we refer to the data parsed from MyAnimeList which is stored temporarily on our servers to provide better API performance.\n\nAll requests, by default are cached for **24 hours** except the following endpoints which have their own unique cache **Time To Live**. \n\n| Request | TTL |\n| ---- | ---- |\n| All (Default) | 24 hours |\n\n\nThe following response headers will detail cache information.\n\n| Header | Remarks |\n| ---- | ---- |\n| `Expires` | Cache expiry date |\n| `Last-Modified` | Cache set date |\n| `X-Request-Fingerprint` | Unique request fingerprint |\n\n\nNote: Caching headers will only be available on single resource requests and their child endpoints. e.g `/anime/1`, `/anime/1/relations`. \nThey won't be available on pages which perform queries, like /anime, or /top/anime, etc.\n\n## Allowed HTTP(s) requests\n\n**Jikan REST API does not provide authenticated requests for MyAnimeList.** This means you can not use it to update your anime/manga list.\nOnly GET requests are supported which return READ-ONLY data.\n\n## HTTP Responses\n\n| HTTP Status | Remarks |\n| ---- | ---- |\n| `200 - OK` | The request was successful |\n| `304 - Not Modified` | You have the latest data (Cache Validation response) |\n| `400 - Bad Request` | You've made an invalid request. Recheck documentation |\n| `404 - Not Found` | The resource was not found or MyAnimeList responded with a `404` |\n| `405 - Method Not Allowed` | Requested Method is not supported for resource. Only `GET` requests are allowed |\n| `429 - Too Many Request` | You are being rate limited by Jikan or MyAnimeList is rate-limiting our servers (specified in the error response) |\n| `500 - Internal Server Error` | Something is not working on our end. If you see an error response with a `report_url` URL, please click on it to open an auto-generated GitHub issue |\n| `503 - Service Unavailable` | The service has broke. |\n\n\n## JSON Error Response\n\n```json\n {\n     \"status\": 404,\n     \"type\": \"BadResponseException\",\n     \"message\": \"Resource does not exist\",\n     \"error\": \"Something Happened\",\n     \"report_url\": \"https://github.com...\"\n  }\n```\n\n| Property | Remarks |\n| ---- | ---- |\n| `status` | Returned HTTP Status Code |\n| `type` | Thrown Exception |\n| `message` | Human-readable error message |\n| `error` | Error response and trace from the API |\n| `report_url` | Clicking this would redirect you to a generated GitHub issue. ℹ It's only returned on a parser error. |\n\n\n## Cache Validation\n\n- All requests return a `ETag` header which is an MD5 hash of the response\n- You can use this hash to verify if there's new or updated content by suppliying it as the value for the `If-None-Match` in your next request header\n- You will get a HTTP `304 - Not Modified` response if the content has not changed\n- If the content has changed, you'll get a HTTP `200 - OK` response with the updated JSON response\n\n![Cache Validation](https://i.imgur.com/925ozVn.png 'Cache Validation')\n\n## Disclaimer\n\n- Jikan is not affiliated with MyAnimeList.net.\n- Jikan is a free, open-source API. Please use it responsibly.\n\n----\n\nBy using the API, you are agreeing to Jikan's [terms of use](https://jikan.moe/terms) policy.\n\n[v3 Documentation](https://jikan.docs.apiary.io/) - [Wrappers/SDKs](https://github.com/jikan-me/jikan#wrappers) - [Report an issue](https://github.com/jikan-me/jikan-rest/issues/new) - [Host your own server](https://github.com/jikan-me/jikan-rest)",
         "termsOfService": "https://jikan.moe/terms",
         "contact": {
             "name": "API Support (Discord)",
@@ -3883,11 +3883,7 @@
                             "data": {
                                 "type": "array",
                                 "items": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/anime"
-                                        }
-                                    ]
+                                    "$ref": "#/components/schemas/anime"
                                 }
                             }
                         },
@@ -3914,6 +3910,23 @@
                             "data": {
                                 "type": "array",
                                 "items": {
+                                    "properties": {
+                                        "url": {
+                                            "description": "MyAnimeList URL",
+                                            "type": "string"
+                                        },
+                                        "username": {
+                                            "description": "MyAnimeList Username",
+                                            "type": "string"
+                                        },
+                                        "": {
+                                            "$ref": "#/components/schemas/user_images"
+                                        },
+                                        "last_online": {
+                                            "description": "Last Online Date ISO8601",
+                                            "type": "string"
+                                        }
+                                    },
                                     "type": "object"
                                 }
                             }
@@ -6250,11 +6263,7 @@
                             "data": {
                                 "type": "array",
                                 "items": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/manga"
-                                        }
-                                    ]
+                                    "$ref": "#/components/schemas/manga"
                                 }
                             }
                         },
@@ -7321,7 +7330,7 @@
                     "data": {
                         "type": "array",
                         "items": {
-                            "type": "object"
+                            "$ref": "#/components/schemas/history"
                         }
                     }
                 },


### PR DESCRIPTION
`@OA\Schema` is not recognized as a direct child of `@OA\Items`. As a result of this for example `users_search` displayed with empty objects inside `data` ([link](https://github.com/jikan-me/jikan-rest/blob/1bd53a09b07f6070b8612c99d21a7a7cbdfe2b9a/storage/api-docs/api-docs.json#L3909-L3927)). This PR fixes this problem.

In addition to this, `@OA\Schema` can be used inside `allOf` but if there is only a single element inside `allOf` then we have unnecessary extra elements inside the generated schema.