### PR TITLE
Fix test cases

### DIFF
--- a/tests/HttpV4/Controllers/AnimeControllerTest.php
+++ b/tests/HttpV4/Controllers/AnimeControllerTest.php
@@ -26,7 +26,7 @@ class AnimeControllerV4Test extends TestCase
                     'url',
                     'embed_url',
                     'images' => [
-                        'default_image_url',
+                        'image_url',
                         'small_image_url',
                         'medium_image_url',
                         'large_image_url',
@@ -154,7 +154,7 @@ class AnimeControllerV4Test extends TestCase
 
     public function testStaff()
     {
-        $this->get('/v4/anime/1/characters')
+        $this->get('/v4/anime/1/staff')
             ->seeStatusCode(200)
             ->seeJsonStructure(['data'=>[
                 [
@@ -179,7 +179,7 @@ class AnimeControllerV4Test extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -201,7 +201,7 @@ class AnimeControllerV4Test extends TestCase
             ->seeJson([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -232,17 +232,19 @@ class AnimeControllerV4Test extends TestCase
         $this->get('/v4/anime/21/episodes/1')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'mal_id',
-                'url',
-                'title',
-                'title_japanese',
-                'title_romanji',
-                'duration',
-                'aired',
-                'aired',
-                'filler',
-                'recap',
-                'synopsis'
+                'data' => [
+                    'mal_id',
+                    'url',
+                    'title',
+                    'title_japanese',
+                    'title_romanji',
+                    'duration',
+                    'aired',
+                    'aired',
+                    'filler',
+                    'recap',
+                    'synopsis',
+                ]
             ]);
     }
 
@@ -253,7 +255,7 @@ class AnimeControllerV4Test extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -261,7 +263,7 @@ class AnimeControllerV4Test extends TestCase
                         'url',
                         'title',
                         'date',
-                        'author_name',
+                        'author_username',
                         'author_url',
                         'forum_url',
                         'images' => [
@@ -281,10 +283,18 @@ class AnimeControllerV4Test extends TestCase
         $this->get('/v4/anime/1/pictures')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'images' => [
+                'data' => [
                     [
-                        'large_image_url',
-                        'small_image_url',
+                        'jpg' => [
+                            'image_url',
+                            'large_image_url',
+                            'small_image_url',
+                        ],
+                        'webp' => [
+                            'image_url',
+                            'large_image_url',
+                            'small_image_url',
+                        ]
                     ]
                 ]
             ]);
@@ -295,16 +305,15 @@ class AnimeControllerV4Test extends TestCase
         $this->get('/v4/anime/1/videos')
             ->seeStatusCode(200)
             ->seeJsonStructure(['data'=>[
-                'promos' => [
+                'promo' => [
                     [
                         'title',
-                        'image_url',
                         'trailer' => [
                             'youtube_id',
                             'url',
                             'embed_url',
                             'images' => [
-                                'default_image_url',
+                                'image_url',
                                 'small_image_url',
                                 'medium_image_url',
                                 'large_image_url',
@@ -319,7 +328,11 @@ class AnimeControllerV4Test extends TestCase
                         'title',
                         'episode',
                         'url',
-                        'image_url',
+                        'images' => [
+                            'jpg' => [
+                                'image_url',
+                            ],
+                        ],
                     ]
                 ]
             ]]);
@@ -357,12 +370,12 @@ class AnimeControllerV4Test extends TestCase
                         'url',
                         'title',
                         'date',
-                        'author_name',
+                        'author_username',
                         'author_url',
                         'comments',
                         'last_comment' => [
                             'url',
-                            'author_name',
+                            'author_username',
                             'author_url',
                             'date'
                         ]
@@ -387,7 +400,7 @@ class AnimeControllerV4Test extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -426,7 +439,7 @@ class AnimeControllerV4Test extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => []
             ]);
@@ -470,7 +483,7 @@ class AnimeControllerV4Test extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -526,10 +539,8 @@ class AnimeControllerV4Test extends TestCase
             ->seeStatusCode(200)
             ->seeJsonStructure([
                 'data' => [
-                    [
-                        'openings',
-                        'endings',
-                    ]
+                    'openings',
+                    'endings',
                 ]
             ]);
     }

--- a/tests/HttpV4/Controllers/CharacterControllerTest.php
+++ b/tests/HttpV4/Controllers/CharacterControllerTest.php
@@ -80,9 +80,9 @@ class CharacterControllerTest extends TestCase
             ]]);
     }
 
-    public function testSeiyuu()
+    public function testVoices()
     {
-        $this->get('/v4/characters/1/seiyuu')
+        $this->get('/v4/characters/1/voices')
             ->seeStatusCode(200)
             ->seeJsonStructure(['data'=>[
                 [
@@ -108,8 +108,9 @@ class CharacterControllerTest extends TestCase
             ->seeJsonStructure([
                 'data' => [
                     [
-                        'image_url',
-                        'large_image_url',
+                        'jpg' => [
+                            'image_url',
+                        ]
                     ]
                 ]
             ]);
@@ -117,7 +118,7 @@ class CharacterControllerTest extends TestCase
 
     public function test404()
     {
-        $this->get('/v4/character/1000000')
+        $this->get('/v4/characters/1000000')
             ->seeStatusCode(404);
     }
 }

--- a/tests/HttpV4/Controllers/ClubControllerTest.php
+++ b/tests/HttpV4/Controllers/ClubControllerTest.php
@@ -8,57 +8,28 @@ class ClubControllerTest extends TestCase
             ->seeStatusCode(200)
             ->seeJsonStructure(['data'=>[
                 'mal_id',
+                'name',
                 'url',
-                'images',
-                'title',
-                'members_count',
-                'pictures_count',
+                'images' => [
+                    'jpg' => [
+                        'image_url',
+                    ],
+                ],
+                'members',
                 'category',
                 'created',
-                'type',
-                'staff' => [
-                    [
-                        'mal_id',
-                        'type',
-                        'name',
-                        'url',
-                    ]
-                ],
-                'anime' => [
-                    [
-                        'mal_id',
-                        'type',
-                        'name',
-                        'url',
-                    ]
-                ],
-                'manga' => [
-                    [
-                        'mal_id',
-                        'type',
-                        'name',
-                        'url',
-                    ]
-                ],
-                'characters' => [
-                    [
-                        'mal_id',
-                        'type',
-                        'name',
-                        'url',
-                    ]
-                ],
+                'access',
             ]]);
     }
 
     public function testMembers()
     {
-        $this->get('/v4/club/1/members')
+        $this->get('/v4/clubs/1/members')
             ->seeStatusCode(200)
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -76,7 +47,7 @@ class ClubControllerTest extends TestCase
                 ]
             ]);
 
-        $this->get('/v4/club/1/members/1000')
+        $this->get('/v4/clubs/1000000/members')
             ->seeStatusCode(404);
     }
 

--- a/tests/HttpV4/Controllers/MangaControllerTest.php
+++ b/tests/HttpV4/Controllers/MangaControllerTest.php
@@ -6,7 +6,7 @@ class MangaControllerV4Test extends TestCase
     {
         $this->get('/v4/manga/1')
             ->seeStatusCode(200)
-            ->seeJsonStructure([
+            ->seeJsonStructure(['data' => [
                 'mal_id',
                 'url',
                 'images' => [
@@ -79,7 +79,7 @@ class MangaControllerV4Test extends TestCase
                         'url'
                     ]
                 ]
-            ]);
+            ]]);
     }
 
     public function testCharacters()
@@ -115,7 +115,7 @@ class MangaControllerV4Test extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -123,7 +123,7 @@ class MangaControllerV4Test extends TestCase
                         'url',
                         'title',
                         'date',
-                        'author_name',
+                        'author_username',
                         'author_url',
                         'forum_url',
                         'images' => [
@@ -143,10 +143,18 @@ class MangaControllerV4Test extends TestCase
         $this->get('/v4/manga/1/pictures')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'images' => [
+                'data' => [
                     [
-                        'large_image_url',
-                        'small_image_url',
+                        'jpg' => [
+                            'image_url',
+                            'large_image_url',
+                            'small_image_url',
+                        ],
+                        'webp' => [
+                            'image_url',
+                            'large_image_url',
+                            'small_image_url',
+                        ],
                     ]
                 ]
             ]);
@@ -184,12 +192,12 @@ class MangaControllerV4Test extends TestCase
                         'url',
                         'title',
                         'date',
-                        'author_name',
+                        'author_username',
                         'author_url',
                         'comments',
                         'last_comment' => [
                             'url',
-                            'author_name',
+                            'author_username',
                             'author_url',
                             'date'
                         ]
@@ -214,7 +222,7 @@ class MangaControllerV4Test extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -252,7 +260,7 @@ class MangaControllerV4Test extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => []
             ]);
@@ -296,7 +304,7 @@ class MangaControllerV4Test extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [

--- a/tests/HttpV4/Controllers/PersonControllerTest.php
+++ b/tests/HttpV4/Controllers/PersonControllerTest.php
@@ -60,7 +60,7 @@ class PersonControllerTest extends TestCase
             ->seeStatusCode(200)
             ->seeJsonStructure(['data'=>[
                 [
-                    'position',
+                    'role',
                     'manga' => [
                         'mal_id',
                         'url',
@@ -82,9 +82,9 @@ class PersonControllerTest extends TestCase
             ]]);
     }
 
-    public function testSeiyuu()
+    public function testVoices()
     {
-        $this->get('/v4/people/1/seiyuu')
+        $this->get('/v4/people/1/voices')
             ->seeStatusCode(200)
             ->seeJsonStructure(['data'=>[
                 [
@@ -132,8 +132,9 @@ class PersonControllerTest extends TestCase
             ->seeJsonStructure([
                 'data' => [
                     [
-                        'large',
-                        'small',
+                        'jpg' => [
+                            'image_url'
+                        ]
                     ]
                 ]
             ]);

--- a/tests/HttpV4/Controllers/RecommendationsControllerTest.php
+++ b/tests/HttpV4/Controllers/RecommendationsControllerTest.php
@@ -10,7 +10,7 @@ class RecommendationsControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [

--- a/tests/HttpV4/Controllers/ReviewsControllerTest.php
+++ b/tests/HttpV4/Controllers/ReviewsControllerTest.php
@@ -10,7 +10,7 @@ class ReviewsControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -30,23 +30,21 @@ class ReviewsControllerTest extends TestCase
                             'enjoyment',
                         ],
                         'entry' => [
-                            [
-                                'mal_id',
-                                'url',
-                                'images' => [
-                                    'jpg' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
-                                    'webp' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
+                            'mal_id',
+                            'url',
+                            'images' => [
+                                'jpg' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
                                 ],
-                                'title'
-                            ]
+                                'webp' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
+                                ],
+                            ],
+                            'title'
                         ],
                         'user' => [
                             'username',
@@ -72,7 +70,7 @@ class ReviewsControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -91,23 +89,21 @@ class ReviewsControllerTest extends TestCase
                             'enjoyment',
                         ],
                         'entry' => [
-                            [
-                                'mal_id',
-                                'url',
-                                'images' => [
-                                    'jpg' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
-                                    'webp' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
+                            'mal_id',
+                            'url',
+                            'images' => [
+                                'jpg' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
                                 ],
-                                'title'
-                            ]
+                                'webp' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
+                                ],
+                            ],
+                            'title'
                         ],
                         'user' => [
                             'username',

--- a/tests/HttpV4/Controllers/SearchControllerTest.php
+++ b/tests/HttpV4/Controllers/SearchControllerTest.php
@@ -4,24 +4,122 @@ class SearchControllerTest extends TestCase
 {
     public function testAnimeSearch()
     {
-        $this->get('/v4/search/anime?order_by=id&sort=asc')
+        $this->get('/v4/anime?order_by=id&sort=asc')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'results' => [
+                'pagination' => [
+                    'last_visible_page',
+                    'has_next_page',
+                    'items' => [
+                        'count',
+                        'total',
+                        'per_page',
+                    ]
+                ],
+                'data' => [
                     [
                         'mal_id',
                         'url',
-                        'image_url',
+                        'images' => [
+                            'jpg' => [
+                                'image_url',
+                                'small_image_url',
+                                'large_image_url'
+                            ],
+                            'webp' => [
+                                'image_url',
+                                'small_image_url',
+                                'large_image_url'
+                            ],
+                        ],
+                        'trailer' => [
+                            'youtube_id',
+                            'url',
+                            'embed_url',
+                            'images' => [
+                                'image_url',
+                                'small_image_url',
+                                'medium_image_url',
+                                'large_image_url',
+                                'maximum_image_url',
+                            ]
+                        ],
                         'title',
-                        'airing',
-                        'synopsis',
+                        'title_english',
+                        'title_japanese',
+                        'title_synonyms',
                         'type',
+                        'source',
                         'episodes',
+                        'status',
+                        'airing',
+                        'aired' => [
+                            'from',
+                            'to',
+                            'prop' => [
+                                'from' => [
+                                    'day',
+                                    'month',
+                                    'year'
+                                ],
+                                'to' => [
+                                    'day',
+                                    'month',
+                                    'year'
+                                ]
+                            ],
+                            'string'
+                        ],
+                        'duration',
+                        'rating',
                         'score',
-                        'start_date',
-                        'end_date',
+                        'scored_by',
+                        'rank',
+                        'popularity',
                         'members',
-                        'rated'
+                        'favorites',
+                        'synopsis',
+                        'background',
+                        'season',
+                        'year',
+                        'broadcast' => [
+                            'day',
+                            'time',
+                            'timezone',
+                            'string'
+                        ],
+                        'producers' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'licensors' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'studios' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'genres' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
                     ]
                 ]
             ])
@@ -30,24 +128,92 @@ class SearchControllerTest extends TestCase
 
     public function testMangaSearch()
     {
-        $this->get('/v4/search/manga?order_by=id&sort=asc')
+        $this->get('/v4/manga?order_by=id&sort=asc')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'results' => [
+                'pagination' => [
+                    'last_visible_page',
+                    'has_next_page',
+                    'items' => [
+                        'count',
+                        'total',
+                        'per_page',
+                    ]
+                ],
+                'data' => [
                     [
                         'mal_id',
                         'url',
-                        'image_url',
+                        'images' => [
+                            'jpg' => [
+                                'image_url',
+                                'small_image_url',
+                                'large_image_url'
+                            ],
+                            'webp' => [
+                                'image_url',
+                                'small_image_url',
+                                'large_image_url'
+                            ],
+                        ],
                         'title',
-                        'publishing',
-                        'synopsis',
+                        'title_english',
+                        'title_japanese',
+                        'title_synonyms',
                         'type',
                         'chapters',
                         'volumes',
+                        'status',
+                        'publishing',
+                        'published' => [
+                            'from',
+                            'to',
+                            'prop' => [
+                                'from' => [
+                                    'day',
+                                    'month',
+                                    'year'
+                                ],
+                                'to' => [
+                                    'day',
+                                    'month',
+                                    'year'
+                                ]
+                            ],
+                            'string'
+                        ],
                         'score',
-                        'start_date',
-                        'end_date',
+                        'scored_by',
+                        'rank',
+                        'popularity',
                         'members',
+                        'favorites',
+                        'synopsis',
+                        'background',
+                        'authors' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'serializations' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'genres' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ]
                     ]
                 ]
             ])
@@ -56,16 +222,35 @@ class SearchControllerTest extends TestCase
 
     public function testPeopleSearch()
     {
-        $this->get('/v4/search/people?q=Sawano')
+        $this->get('/v4/people?q=Sawano')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'results' => [
+                'pagination' => [
+                    'last_visible_page',
+                    'has_next_page',
+                    'items' => [
+                        'count',
+                        'total',
+                        'per_page',
+                    ]
+                ],
+                'data' => [
                     [
                         'mal_id',
                         'url',
-                        'image_url',
+                        'website_url',
+                        'images' => [
+                            'jpg' => [
+                                'image_url',
+                            ],
+                        ],
                         'name',
-                        'alternative_names',
+                        'given_name',
+                        'family_name',
+                        'alternate_names',
+                        'birthday',
+                        'favorites',
+                        'about',
                     ]
                 ]
             ])
@@ -74,28 +259,36 @@ class SearchControllerTest extends TestCase
 
     public function testCharacterSearch()
     {
-        $this->get('/v4/search/character?q=Okabe,%20Rintarou')
+        $this->get('/v4/characters?q=Okabe,%20Rintarou')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'results' => [
+                'pagination' => [
+                    'last_visible_page',
+                    'has_next_page',
+                    'items' => [
+                        'count',
+                        'total',
+                        'per_page',
+                    ]
+                ],
+                'data' => [
                     [
                         'mal_id',
                         'url',
-                        'image_url',
-                        'name',
-                        'alternative_names',
-                        'anime' => [
-                            [
-                                'mal_id',
-                                'type',
-                                'name', // todo should be `title`
-                                'url'
-                            ]
+                        'images' => [
+                            'jpg' => [
+                                'image_url',
+                            ],
+                            'webp' => [
+                                'image_url',
+                            ],
                         ],
-                        'manga' => [],
+                        'name',
+                        'nicknames',
+                        'favorites',
+                        'about',
                     ]
                 ],
-                'last_page'
             ])
         ;
     }

--- a/tests/HttpV4/Controllers/SeasonControllerTest.php
+++ b/tests/HttpV4/Controllers/SeasonControllerTest.php
@@ -8,8 +8,10 @@ class SeasonControllerTest extends TestCase
             ->seeStatusCode(200)
             ->seeJsonStructure([
                 'data' => [
-                    'year',
-                    'seasons'
+                    [
+                        'year',
+                        'seasons'
+                    ]
                 ]
             ]);
 

--- a/tests/HttpV4/Controllers/TopControllerTest.php
+++ b/tests/HttpV4/Controllers/TopControllerTest.php
@@ -7,18 +7,110 @@ class TopControllerTest extends TestCase
         $this->get('/v4/top/anime')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'top' => [
+                'data' => [
                     [
                         'mal_id',
-                        'rank',
-                        'title',
                         'url',
-                        'image_url',
+                        'images' => [
+                            'jpg' => [
+                                'image_url',
+                                'small_image_url',
+                                'large_image_url'
+                            ],
+                            'webp' => [
+                                'image_url',
+                                'small_image_url',
+                                'large_image_url'
+                            ],
+                        ],
+                        'trailer' => [
+                            'youtube_id',
+                            'url',
+                            'embed_url',
+                            'images' => [
+                                'image_url',
+                                'small_image_url',
+                                'medium_image_url',
+                                'large_image_url',
+                                'maximum_image_url',
+                            ]
+                        ],
+                        'title',
+                        'title_english',
+                        'title_japanese',
+                        'title_synonyms',
                         'type',
-                        'start_date',
-                        'end_date',
-                        'members',
+                        'source',
+                        'episodes',
+                        'status',
+                        'airing',
+                        'aired' => [
+                            'from',
+                            'to',
+                            'prop' => [
+                                'from' => [
+                                    'day',
+                                    'month',
+                                    'year'
+                                ],
+                                'to' => [
+                                    'day',
+                                    'month',
+                                    'year'
+                                ]
+                            ],
+                            'string'
+                        ],
+                        'duration',
+                        'rating',
                         'score',
+                        'scored_by',
+                        'rank',
+                        'popularity',
+                        'members',
+                        'favorites',
+                        'synopsis',
+                        'background',
+                        'season',
+                        'year',
+                        'broadcast' => [
+                            'day',
+                            'time',
+                            'timezone',
+                            'string'
+                        ],
+                        'producers' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'licensors' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'studios' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'genres' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
                     ]
                 ]
             ]);
@@ -29,19 +121,80 @@ class TopControllerTest extends TestCase
         $this->get('/v4/top/manga')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'top' => [
+                'data' => [
                     [
                         'mal_id',
-                        'rank',
-                        'title',
                         'url',
+                        'images' => [
+                            'jpg' => [
+                                'image_url',
+                                'small_image_url',
+                                'large_image_url'
+                            ],
+                            'webp' => [
+                                'image_url',
+                                'small_image_url',
+                                'large_image_url'
+                            ],
+                        ],
+                        'title',
+                        'title_english',
+                        'title_japanese',
+                        'title_synonyms',
                         'type',
+                        'chapters',
                         'volumes',
-                        'start_date',
-                        'end_date',
-                        'members',
+                        'status',
+                        'publishing',
+                        'published' => [
+                            'from',
+                            'to',
+                            'prop' => [
+                                'from' => [
+                                    'day',
+                                    'month',
+                                    'year'
+                                ],
+                                'to' => [
+                                    'day',
+                                    'month',
+                                    'year'
+                                ]
+                            ],
+                            'string'
+                        ],
                         'score',
-                        'image_url',
+                        'scored_by',
+                        'rank',
+                        'popularity',
+                        'members',
+                        'favorites',
+                        'synopsis',
+                        'background',
+                        'authors' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'serializations' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ],
+                        'genres' => [
+                            [
+                                'mal_id',
+                                'type',
+                                'name',
+                                'url'
+                            ]
+                        ]
                     ]
                 ]
             ]);
@@ -52,16 +205,23 @@ class TopControllerTest extends TestCase
         $this->get('/v4/top/people')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'top' => [
+                'data' => [
                     [
                         'mal_id',
-                        'rank',
-                        'title', // todo should be `name`
                         'url',
-                        'name_kanji',
-                        'favorites',
-                        'image_url',
+                        'website_url',
+                        'images' => [
+                            'jpg' => [
+                                'image_url',
+                            ],
+                        ],
+                        'name',
+                        'given_name',
+                        'family_name',
+                        'alternate_names',
                         'birthday',
+                        'favorites',
+                        'about',
                     ]
                 ]
             ]);
@@ -72,32 +232,22 @@ class TopControllerTest extends TestCase
         $this->get('/v4/top/characters')
             ->seeStatusCode(200)
             ->seeJsonStructure([
-                'top' => [
+                'data' => [
                     [
                         'mal_id',
-                        'rank',
-                        'title', // todo should be `name`
                         'url',
-                        'name_kanji',
-
-                        'animeography' => [
-                            [
-                                'mal_id',
-                                'type',
-                                'name',
-                                'url'
-                            ]
+                        'images' => [
+                            'jpg' => [
+                                'image_url',
+                            ],
+                            'webp' => [
+                                'image_url',
+                            ],
                         ],
-                        'mangaography' => [
-                            [
-                                'mal_id',
-                                'type',
-                                'name',
-                                'url'
-                            ]
-                        ],
+                        'name',
+                        'nicknames',
                         'favorites',
-                        'image_url',
+                        'about',
                     ]
                 ]
             ]);

--- a/tests/HttpV4/Controllers/UserControllerTest.php
+++ b/tests/HttpV4/Controllers/UserControllerTest.php
@@ -129,12 +129,6 @@ class UserControllerTest extends TestCase
                             ],
                         ],
                         'name',
-                        'entry' => [
-                            'mal_id',
-                            'title',
-                            'type',
-                            'url'
-                        ]
                     ]
                 ],
                 'people' => [
@@ -190,7 +184,7 @@ class UserControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -216,131 +210,6 @@ class UserControllerTest extends TestCase
             ->seeStatusCode(404);
     }
 
-    public function testUserAnimeList()
-    {
-        $this->get('/v4/users/nekomata1037/animelist?order_by=last_updated&sort=descending')
-            ->seeStatusCode(200)
-            ->seeJsonStructure([
-                'data' => [
-                    [
-                        'watching_status',
-                        'score',
-                        'episodes_watched',
-                        'tags',
-                        'is_rewatching',
-                        'watch_start_date',
-                        'watch_end_date',
-                        'days',
-                        'storage',
-                        'priority',
-                        'anime' => [
-                            'mal_id',
-                            'title',
-                            'url',
-                            'images' => [
-                                'jpg' => [
-                                    'image_url',
-                                    'small_image_url',
-                                    'large_image_url'
-                                ],
-                                'webp' => [
-                                    'image_url',
-                                    'small_image_url',
-                                    'large_image_url'
-                                ],
-                            ],
-                        ],
-                        'type',
-                        'season',
-                        'year',
-                        'episodes',
-                        'rating',
-                        'airing',
-                        'aired' => [
-                            'from',
-                            'to',
-                            'prop' => [
-                                'from' => [
-                                    'day',
-                                    'month',
-                                    'year'
-                                ],
-                                'to' => [
-                                    'day',
-                                    'month',
-                                    'year'
-                                ]
-                            ],
-                            'string'
-                        ],
-                        'studios',
-                        'licensors'
-                    ]
-                ]
-            ]);
-    }
-
-    public function testUserMangaList()
-    {
-        $this->get('/v4/users/purplepinapples/mangalist?order_by=last_updated&sort=descending')
-            ->seeStatusCode(200)
-            ->seeJsonStructure([
-                'data' => [
-                    [
-                        'reading_status',
-                        'score',
-                        'chapters_read',
-                        'tags',
-                        'is_rereading',
-                        'read_start_date',
-                        'read_end_date',
-                        'days',
-                        'retail',
-                        'priority',
-                        'manga' => [
-                            'mal_id',
-                            'title',
-                            'url',
-                            'images' => [
-                                'jpg' => [
-                                    'image_url',
-                                    'small_image_url',
-                                    'large_image_url'
-                                ],
-                                'webp' => [
-                                    'image_url',
-                                    'small_image_url',
-                                    'large_image_url'
-                                ],
-                            ],
-                        ],
-                        'type',
-                        'chapters',
-                        'volumes',
-                        'publishing',
-                        'published' => [
-                            'from',
-                            'to',
-                            'prop' => [
-                                'from' => [
-                                    'day',
-                                    'month',
-                                    'year'
-                                ],
-                                'to' => [
-                                    'day',
-                                    'month',
-                                    'year'
-                                ]
-                            ],
-                            'string'
-                        ],
-                        'magazines'
-                    ]
-                ]
-            ]);
-    }
-
     public function testUserRecommendations()
     {
         $this->get('/v4/users/xinil/recommendations')
@@ -348,7 +217,7 @@ class UserControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -384,7 +253,7 @@ class UserControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                 ]
@@ -398,7 +267,7 @@ class UserControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
@@ -409,23 +278,21 @@ class UserControllerTest extends TestCase
                         'date',
                         'review',
                         'entry' => [
-                            [
-                                'mal_id',
-                                'url',
-                                'images' => [
-                                    'jpg' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
-                                    'webp' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
+                            'mal_id',
+                            'url',
+                            'images' => [
+                                'jpg' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
                                 ],
-                                'title'
-                            ]
+                                'webp' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
+                                ],
+                            ],
+                            'title'
                         ],
                     ]
                 ]
@@ -448,7 +315,7 @@ class UserControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [

--- a/tests/HttpV4/Controllers/WatchControllerTest.php
+++ b/tests/HttpV4/Controllers/WatchControllerTest.php
@@ -10,34 +10,32 @@ class WatchControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
                         'entry' => [
-                            [
-                                'mal_id',
-                                'url',
-                                'images' => [
-                                    'jpg' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
-                                    'webp' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
+                            'mal_id',
+                            'url',
+                            'images' => [
+                                'jpg' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
                                 ],
-                                'title'
-                            ]
+                                'webp' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
+                                ],
+                            ],
+                            'title'
                         ],
                         'episodes' => [
                             [
                                 'mal_id',
                                 'url',
-                                'name',
+                                'title',
                                 'premium'
                             ]
                         ],
@@ -45,39 +43,37 @@ class WatchControllerTest extends TestCase
                 ]
             ]);
 
-        $this->get('/v4/watch/popular')
+        $this->get('/v4/watch/episodes/popular')
             ->seeStatusCode(200)
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
                         'entry' => [
-                            [
-                                'mal_id',
-                                'url',
-                                'images' => [
-                                    'jpg' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
-                                    'webp' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
+                            'mal_id',
+                            'url',
+                            'images' => [
+                                'jpg' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
                                 ],
-                                'title'
-                            ]
+                                'webp' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
+                                ],
+                            ],
+                            'title'
                         ],
                         'episodes' => [
                             [
                                 'mal_id',
                                 'url',
-                                'name',
+                                'title',
                                 'premium'
                             ]
                         ],
@@ -93,36 +89,34 @@ class WatchControllerTest extends TestCase
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
                         'title',
                         'entry' => [
-                            [
-                                'mal_id',
-                                'url',
-                                'images' => [
-                                    'jpg' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
-                                    'webp' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
+                            'mal_id',
+                            'url',
+                            'images' => [
+                                'jpg' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
                                 ],
-                                'title'
-                            ]
+                                'webp' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
+                                ],
+                            ],
+                            'title'
                         ],
                         'trailer' => [
                             'youtube_id',
                             'url',
                             'embed_url',
                             'images' => [
-                                'default_image_url',
+                                'image_url',
                                 'small_image_url',
                                 'medium_image_url',
                                 'large_image_url',
@@ -133,41 +127,39 @@ class WatchControllerTest extends TestCase
                 ]
             ]);
 
-        $this->get('/v4/watch/popular')
+        $this->get('/v4/watch/promos/popular')
             ->seeStatusCode(200)
             ->seeJsonStructure([
                 'pagination' => [
                     'last_visible_page',
-                    'hast_next_page',
+                    'has_next_page',
                 ],
                 'data' => [
                     [
                         'title',
                         'entry' => [
-                            [
-                                'mal_id',
-                                'url',
-                                'images' => [
-                                    'jpg' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
-                                    'webp' => [
-                                        'image_url',
-                                        'small_image_url',
-                                        'large_image_url'
-                                    ],
+                            'mal_id',
+                            'url',
+                            'images' => [
+                                'jpg' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
                                 ],
-                                'title'
-                            ]
+                                'webp' => [
+                                    'image_url',
+                                    'small_image_url',
+                                    'large_image_url'
+                                ],
+                            ],
+                            'title'
                         ],
                         'trailer' => [
                             'youtube_id',
                             'url',
                             'embed_url',
                             'images' => [
-                                'default_image_url',
+                                'image_url',
                                 'small_image_url',
                                 'medium_image_url',
                                 'large_image_url',


### PR DESCRIPTION
The current master branch contains 79 tests and 52 fails.

Info:

- `getUserAnimelist` and `getUserMangaList` tests are removed because they are discontinued since May 1st, 2022.
- Reduced failing tests to 14.
  - 1 of them related to #238 