### PR TITLE
Upgrade composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2938,16 +2938,16 @@
         },
         {
             "name": "jikan-me/jikan",
-            "version": "v3.0.2",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jikan-me/jikan.git",
-                "reference": "cf7083f1d50eef3e20535b6c57760f59ec89b787"
+                "reference": "88339995b29b69b45b33062ca7cd056665169da7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jikan-me/jikan/zipball/cf7083f1d50eef3e20535b6c57760f59ec89b787",
-                "reference": "cf7083f1d50eef3e20535b6c57760f59ec89b787",
+                "url": "https://api.github.com/repos/jikan-me/jikan/zipball/88339995b29b69b45b33062ca7cd056665169da7",
+                "reference": "88339995b29b69b45b33062ca7cd056665169da7",
                 "shasum": ""
             },
             "require": {
@@ -2986,7 +2986,7 @@
             "description": "Jikan is an unofficial MyAnimeList API",
             "support": {
                 "issues": "https://github.com/jikan-me/jikan/issues",
-                "source": "https://github.com/jikan-me/jikan/tree/v3.0.2"
+                "source": "https://github.com/jikan-me/jikan/tree/v3.1.0"
             },
             "funding": [
                 {
@@ -2994,7 +2994,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-06-21T15:07:20+00:00"
+            "time": "2022-06-30T22:08:39+00:00"
         },
         {
             "name": "jms/metadata",


### PR DESCRIPTION
Because `jikan-me/jikan` was out of date some feature is not available in the current release. 

Could we use dependabot in the future to detect version upgrades and make them almost automatic?

Related to jikan-me/jikan#446