### PR TITLE
Feature/adds new parser data for Anime, Manga, and Users

### DIFF
--- a/app/Http/Controllers/V4DB/UserController.php
+++ b/app/Http/Controllers/V4DB/UserController.php
@@ -25,7 +25,8 @@ use Jikan\Request\User\UserReviewsRequest;
 use MongoDB\BSON\UTCDateTime;
 
 /**
- *
+ * Class Controller
+ * @package App\Http\Controllers\V4DB
  */
 class UserController extends Controller
 {

--- a/app/Http/Resources/V4/AnimeFullResource.php
+++ b/app/Http/Resources/V4/AnimeFullResource.php
@@ -30,21 +30,37 @@ class AnimeFullResource extends JsonResource
      *          ref="#/components/schemas/trailer_base"
      *      ),
      *      @OA\Property(
+     *          property="approved",
+     *          type="boolean",
+     *          description="Whether the entry is pending approval on MAL or not"
+     *      ),
+     *      @OA\Property(
+     *          property="titles",
+     *          type="array",
+     *          description="All titles",
+     *          @OA\Items(
+     *              type="string"
+     *          )
+     *      ),
+     *      @OA\Property(
      *          property="title",
      *          type="string",
-     *          description="Title"
+     *          description="Title",
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_english",
      *          type="string",
      *          description="English Title",
-     *          nullable=true
+     *          nullable=true,
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_japanese",
      *          type="string",
      *          description="Japanese Title",
-     *          nullable=true
+     *          nullable=true,
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_synonyms",
@@ -52,7 +68,8 @@ class AnimeFullResource extends JsonResource
      *          description="Other Titles",
      *          @OA\Items(
      *              type="string"
-     *          )
+     *          ),
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="type",
@@ -283,6 +300,24 @@ class AnimeFullResource extends JsonResource
      *              ),
      *          ),
      *      ),
+     *
+     *      @OA\Property(
+     *          property="streaming",
+     *          type="array",
+     *
+     *          @OA\Items(
+     *              type="object",
+     *
+     *              @OA\Property(
+     *                   property="name",
+     *                   type="string",
+     *              ),
+     *              @OA\Property(
+     *                   property="url",
+     *                   type="string",
+     *              ),
+     *          ),
+     *      ),
      *  )
      */
 
@@ -299,6 +334,8 @@ class AnimeFullResource extends JsonResource
             'url' => $this->url,
             'images' => $this->images,
             'trailer' => $this->trailer,
+            'approved' => $this->approved ?? true,
+            'titles' => $this->titles ?? [],
             'title' => $this->title,
             'title_english' => $this->title_english,
             'title_japanese' => $this->title_japanese,
@@ -335,6 +372,7 @@ class AnimeFullResource extends JsonResource
                 'endings' => $this->ending_themes
             ],
             'external' => $this->external_links,
+            'streaming' => $this->streaming_links,
         ];
     }
 }

--- a/app/Http/Resources/V4/AnimeResource.php
+++ b/app/Http/Resources/V4/AnimeResource.php
@@ -30,21 +30,37 @@ class AnimeResource extends JsonResource
      *          ref="#/components/schemas/trailer_base"
      *      ),
      *      @OA\Property(
+     *          property="approved",
+     *          type="boolean",
+     *          description="Whether the entry is pending approval on MAL or not"
+     *      ),
+     *      @OA\Property(
+     *          property="titles",
+     *          type="array",
+     *          description="All titles",
+     *          @OA\Items(
+     *              type="string"
+     *          )
+     *      ),
+     *      @OA\Property(
      *          property="title",
      *          type="string",
-     *          description="Title"
+     *          description="Title",
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_english",
      *          type="string",
      *          description="English Title",
-     *          nullable=true
+     *          nullable=true,
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_japanese",
      *          type="string",
      *          description="Japanese Title",
-     *          nullable=true
+     *          nullable=true,
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_synonyms",
@@ -52,7 +68,8 @@ class AnimeResource extends JsonResource
      *          description="Other Titles",
      *          @OA\Items(
      *              type="string"
-     *          )
+     *          ),
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="type",
@@ -240,6 +257,8 @@ class AnimeResource extends JsonResource
             'url' => $this->url,
             'images' => $this->images,
             'trailer' => $this->trailer,
+            'approved' => $this->approved ?? true,
+            'titles' => $this->titles ?? [],
             'title' => $this->title,
             'title_english' => $this->title_english,
             'title_japanese' => $this->title_japanese,

--- a/app/Http/Resources/V4/MangaFullResource.php
+++ b/app/Http/Resources/V4/MangaFullResource.php
@@ -26,21 +26,37 @@ class MangaFullResource extends JsonResource
      *          ref="#/components/schemas/manga_images"
      *      ),
      *      @OA\Property(
+     *          property="approved",
+     *          type="boolean",
+     *          description="Whether the entry is pending approval on MAL or not"
+     *      ),
+     *      @OA\Property(
+     *          property="titles",
+     *          type="array",
+     *          description="All Titles",
+     *          @OA\Items(
+     *              type="string"
+     *          )
+     *      ),
+     *      @OA\Property(
      *          property="title",
      *          type="string",
-     *          description="Title"
+     *          description="Title",
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_english",
      *          type="string",
      *          description="English Title",
-     *          nullable=true
+     *          nullable=true,
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_japanese",
      *          type="string",
      *          description="Japanese Title",
-     *          nullable=true
+     *          nullable=true,
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_synonyms",
@@ -48,7 +64,8 @@ class MangaFullResource extends JsonResource
      *          description="Other Titles",
      *          @OA\Items(
      *              type="string"
-     *          )
+     *          ),
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="type",
@@ -234,6 +251,8 @@ class MangaFullResource extends JsonResource
             'mal_id' => $this->mal_id,
             'url' => $this->url,
             'images' => $this->images,
+            'approved' => $this->approved ?? true,
+            'titles' => $this->titles ?? [],
             'title' => $this->title,
             'title_english' => $this->title_english,
             'title_japanese' => $this->title_japanese,

--- a/app/Http/Resources/V4/MangaResource.php
+++ b/app/Http/Resources/V4/MangaResource.php
@@ -26,29 +26,37 @@ class MangaResource extends JsonResource
      *          ref="#/components/schemas/manga_images"
      *      ),
      *      @OA\Property(
+     *          property="approved",
+     *          type="boolean",
+     *          description="Whether the entry is pending approval on MAL or not"
+     *      ),
+     *      @OA\Property(
+     *          property="titles",
+     *          type="array",
+     *          description="All Titles",
+     *          @OA\Items(
+     *              type="string"
+     *          )
+     *      ),
+     *      @OA\Property(
      *          property="title",
      *          type="string",
-     *          description="Title"
+     *          description="Title",
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_english",
      *          type="string",
      *          description="English Title",
-     *          nullable=true
+     *          nullable=true,
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="title_japanese",
      *          type="string",
      *          description="Japanese Title",
-     *          nullable=true
-     *      ),
-     *      @OA\Property(
-     *          property="title_synonyms",
-     *          type="array",
-     *          description="Other Titles",
-     *          @OA\Items(
-     *              type="string"
-     *          )
+     *          nullable=true,
+     *          deprecated=true
      *      ),
      *      @OA\Property(
      *          property="type",
@@ -194,6 +202,8 @@ class MangaResource extends JsonResource
             'mal_id' => $this->mal_id,
             'url' => $this->url,
             'images' => $this->images,
+            'approved' => $this->approved ?? true,
+            'titles' => $this->titles ?? [],
             'title' => $this->title,
             'title_english' => $this->title_english,
             'title_japanese' => $this->title_japanese,

--- a/app/Http/Resources/V4/ProfileFullResource.php
+++ b/app/Http/Resources/V4/ProfileFullResource.php
@@ -68,128 +68,143 @@ class ProfileFullResource extends JsonResource
      *          description="Joined Date ISO8601",
      *          nullable=true
      *      ),
-     *
      *     @OA\Property(
      *          property="statistics",
      *          type="object",
+     *          @OA\Property(
+     *              property="anime",
+     *              type="object",
+     *              description="Anime Statistics",
      *              @OA\Property(
-     *                  property="anime",
-     *                  type="object",
-     *                  description="Anime Statistics",
-     *                  @OA\Property(
-     *                      property="days_watched",
-     *                      type="number",
-     *                      format="float",
-     *                      description="Number of days spent watching Anime"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="mean_score",
-     *                      type="number",
-     *                      format="float",
-     *                      description="Mean Score"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="watching",
-     *                      type="integer",
-     *                      description="Anime Watching"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="completed",
-     *                      type="integer",
-     *                      description="Anime Completed"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="on_hold",
-     *                      type="integer",
-     *                      description="Anime On-Hold"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="dropped",
-     *                      type="integer",
-     *                      description="Anime Dropped"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="plan_to_watch",
-     *                      type="integer",
-     *                      description="Anime Planned to Watch"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="total_entries",
-     *                      type="integer",
-     *                      description="Total Anime entries on User list"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="rewatched",
-     *                      type="integer",
-     *                      description="Anime re-watched"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="episodes_watched",
-     *                      type="integer",
-     *                      description="Number of Anime Episodes Watched"
-     *                  ),
+     *                  property="days_watched",
+     *                  type="number",
+     *                  format="float",
+     *                  description="Number of days spent watching Anime"
      *              ),
      *              @OA\Property(
-     *                  property="manga",
-     *                  type="object",
-     *                  description="Manga Statistics",
-     *                  @OA\Property(
-     *                      property="days_read",
-     *                      type="number",
-     *                      format="float",
-     *                      description="Number of days spent reading Manga"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="mean_score",
-     *                      type="number",
-     *                      format="float",
-     *                      description="Mean Score"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="reading",
-     *                      type="integer",
-     *                      description="Manga Reading"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="completed",
-     *                      type="integer",
-     *                      description="Manga Completed"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="on_hold",
-     *                      type="integer",
-     *                      description="Manga On-Hold"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="dropped",
-     *                      type="integer",
-     *                      description="Manga Dropped"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="plan_to_read",
-     *                      type="integer",
-     *                      description="Manga Planned to Read"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="total_entries",
-     *                      type="integer",
-     *                      description="Total Manga entries on User list"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="reread",
-     *                      type="integer",
-     *                      description="Manga re-read"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="chapters_read",
-     *                      type="integer",
-     *                      description="Number of Manga Chapters Read"
-     *                  ),
-     *                  @OA\Property(
-     *                      property="volumes_read",
-     *                      type="integer",
-     *                      description="Number of Manga Volumes Read"
-     *                  ),
+     *                  property="mean_score",
+     *                  type="number",
+     *                  format="float",
+     *                  description="Mean Score"
+     *              ),
+     *              @OA\Property(
+     *                  property="watching",
+     *                  type="integer",
+     *                  description="Anime Watching"
+     *              ),
+     *              @OA\Property(
+     *                  property="completed",
+     *                  type="integer",
+     *                  description="Anime Completed"
+     *              ),
+     *              @OA\Property(
+     *                  property="on_hold",
+     *                  type="integer",
+     *                  description="Anime On-Hold"
+     *              ),
+     *              @OA\Property(
+     *                  property="dropped",
+     *                  type="integer",
+     *                  description="Anime Dropped"
+     *              ),
+     *              @OA\Property(
+     *                  property="plan_to_watch",
+     *                  type="integer",
+     *                  description="Anime Planned to Watch"
+     *              ),
+     *              @OA\Property(
+     *                  property="total_entries",
+     *                  type="integer",
+     *                  description="Total Anime entries on User list"
+     *              ),
+     *              @OA\Property(
+     *                  property="rewatched",
+     *                  type="integer",
+     *                  description="Anime re-watched"
+     *              ),
+     *              @OA\Property(
+     *                  property="episodes_watched",
+     *                  type="integer",
+     *                  description="Number of Anime Episodes Watched"
+     *              ),
+     *          ),
+     *          @OA\Property(
+     *              property="manga",
+     *              type="object",
+     *              description="Manga Statistics",
+     *              @OA\Property(
+     *                  property="days_read",
+     *                  type="number",
+     *                  format="float",
+     *                  description="Number of days spent reading Manga"
+     *              ),
+     *              @OA\Property(
+     *                  property="mean_score",
+     *                  type="number",
+     *                  format="float",
+     *                  description="Mean Score"
+     *              ),
+     *              @OA\Property(
+     *                  property="reading",
+     *                  type="integer",
+     *                  description="Manga Reading"
+     *              ),
+     *              @OA\Property(
+     *                  property="completed",
+     *                  type="integer",
+     *                  description="Manga Completed"
+     *              ),
+     *              @OA\Property(
+     *                  property="on_hold",
+     *                  type="integer",
+     *                  description="Manga On-Hold"
+     *              ),
+     *              @OA\Property(
+     *                  property="dropped",
+     *                  type="integer",
+     *                  description="Manga Dropped"
+     *              ),
+     *              @OA\Property(
+     *                  property="plan_to_read",
+     *                  type="integer",
+     *                  description="Manga Planned to Read"
+     *              ),
+     *              @OA\Property(
+     *                  property="total_entries",
+     *                  type="integer",
+     *                  description="Total Manga entries on User list"
+     *              ),
+     *              @OA\Property(
+     *                  property="reread",
+     *                  type="integer",
+     *                  description="Manga re-read"
+     *              ),
+     *              @OA\Property(
+     *                  property="chapters_read",
+     *                  type="integer",
+     *                  description="Number of Manga Chapters Read"
+     *              ),
+     *              @OA\Property(
+     *                  property="volumes_read",
+     *                  type="integer",
+     *                  description="Number of Manga Volumes Read"
+     *              ),
+     *          ),
+     *      ),
+     *      @OA\Property(
+     *          property="external",
+     *          type="array",
+     *
+     *          @OA\Items(
+     *              type="object",
+     *
+     *              @OA\Property(
+     *                   property="name",
+     *                   type="string",
+     *              ),
+     *              @OA\Property(
+     *                   property="url",
+     *                   type="string",
      *              ),
      *          ),
      *      ),
@@ -215,6 +230,7 @@ class ProfileFullResource extends JsonResource
             'favorites' => $this->favorites,
             'updates' => $this->last_updates,
             'about' => $this->about,
+            'external' => $this->external_links
         ];
     }
 }

--- a/app/Http/Resources/V4/StreamingLinksResource.php
+++ b/app/Http/Resources/V4/StreamingLinksResource.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Resources\V4;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StreamingLinksResource extends JsonResource
+{
+
+    /**
+     *  @OA\Schema(
+     *      schema="streaming_links",
+     *      description="Streaming links",
+     *
+     *      @OA\Property(
+     *          property="data",
+     *          type="array",
+     *
+     *          @OA\Items(
+     *              type="object",
+     *
+     *              @OA\Property(
+     *                   property="name",
+     *                   type="string",
+     *              ),
+     *              @OA\Property(
+     *                   property="url",
+     *                   type="string",
+     *              ),
+     *          ),
+     *      ),
+     *  )
+     */
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->streaming_links;
+    }
+}

--- a/routes/web.v4.php
+++ b/routes/web.v4.php
@@ -102,6 +102,10 @@ $router->group(
         $router->get('/external', [
             'uses' => 'AnimeController@external'
         ]);
+
+        $router->get('/streaming', [
+            'uses' => 'AnimeController@streaming'
+        ]);
     }
 );
 
@@ -362,6 +366,10 @@ $router->group(
 
                 $router->get('/clubs', [
                     'uses' => 'UserController@clubs'
+                ]);
+
+                $router->get('/external', [
+                    'uses' => 'UserController@external'
                 ]);
             }
         );

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -669,6 +669,39 @@
                 }
             }
         },
+        "/anime/{id}/streaming": {
+            "get": {
+                "tags": [
+                    "anime"
+                ],
+                "operationId": "getAnimeStreaming",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns anime streaming links",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/external_links"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error: Bad request. When required parameters were not supplied."
+                    }
+                }
+            }
+        },
         "/characters/{id}/full": {
             "get": {
                 "tags": [
@@ -3661,6 +3694,39 @@
                 }
             }
         },
+        "/users/{username}/external": {
+            "get": {
+                "tags": [
+                    "users"
+                ],
+                "operationId": "getUserExternal",
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns user's external links",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/external_links"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error: Bad request. When required parameters were not supplied."
+                    }
+                }
+            }
+        },
         "/watch/episodes": {
             "get": {
                 "tags": [
@@ -4557,26 +4623,41 @@
                     "trailer": {
                         "$ref": "#/components/schemas/trailer_base"
                     },
+                    "approved": {
+                        "description": "Whether the entry is pending approval on MAL or not",
+                        "type": "boolean"
+                    },
+                    "titles": {
+                        "description": "All titles",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "title": {
                         "description": "Title",
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
                     },
                     "title_english": {
                         "description": "English Title",
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "title_japanese": {
                         "description": "Japanese Title",
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "title_synonyms": {
                         "description": "Other Titles",
                         "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "deprecated": true
                     },
                     "type": {
                         "description": "Anime Type",
@@ -4786,6 +4867,20 @@
                             },
                             "type": "object"
                         }
+                    },
+                    "streaming": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
                     }
                 },
                 "type": "object"
@@ -4831,26 +4926,41 @@
                     "trailer": {
                         "$ref": "#/components/schemas/trailer_base"
                     },
+                    "approved": {
+                        "description": "Whether the entry is pending approval on MAL or not",
+                        "type": "boolean"
+                    },
+                    "titles": {
+                        "description": "All titles",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "title": {
                         "description": "Title",
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
                     },
                     "title_english": {
                         "description": "English Title",
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "title_japanese": {
                         "description": "Japanese Title",
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "title_synonyms": {
                         "description": "Other Titles",
                         "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "deprecated": true
                     },
                     "type": {
                         "description": "Anime Type",
@@ -6343,26 +6453,41 @@
                     "images": {
                         "$ref": "#/components/schemas/manga_images"
                     },
+                    "approved": {
+                        "description": "Whether the entry is pending approval on MAL or not",
+                        "type": "boolean"
+                    },
+                    "titles": {
+                        "description": "All Titles",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "title": {
                         "description": "Title",
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
                     },
                     "title_english": {
                         "description": "English Title",
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "title_japanese": {
                         "description": "Japanese Title",
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "title_synonyms": {
                         "description": "Other Titles",
                         "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "deprecated": true
                     },
                     "type": {
                         "description": "Manga Type",
@@ -6530,26 +6655,33 @@
                     "images": {
                         "$ref": "#/components/schemas/manga_images"
                     },
-                    "title": {
-                        "description": "Title",
-                        "type": "string"
+                    "approved": {
+                        "description": "Whether the entry is pending approval on MAL or not",
+                        "type": "boolean"
                     },
-                    "title_english": {
-                        "description": "English Title",
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "title_japanese": {
-                        "description": "Japanese Title",
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "title_synonyms": {
-                        "description": "Other Titles",
+                    "titles": {
+                        "description": "All Titles",
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "title": {
+                        "description": "Title",
+                        "type": "string",
+                        "deprecated": true
+                    },
+                    "title_english": {
+                        "description": "English Title",
+                        "type": "string",
+                        "nullable": true,
+                        "deprecated": true
+                    },
+                    "title_japanese": {
+                        "description": "Japanese Title",
+                        "type": "string",
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "type": {
                         "description": "Manga Type",
@@ -7360,6 +7492,20 @@
                             }
                         },
                         "type": "object"
+                    },
+                    "external": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
                     }
                 },
                 "type": "object"
@@ -8125,6 +8271,26 @@
                         "$ref": "#/components/schemas/pagination"
                     }
                 ]
+            },
+            "streaming_links": {
+                "description": "Streaming links",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
             },
             "anime_userupdates": {
                 "description": "Anime User Updates Resource",


### PR DESCRIPTION
### Anime

1. Adds streaming links under `GET /anime/{id}/streaming`
2. Adds streaming links under `GET /anime/{id}/full` as `streaming`
3. Adds `approved` boolean property
4. Adds `titles` array and deprecates `title`, `titleEnglish`, `titleJapanese`, and `titleSynonyms`

### Manga

1. Adds `approved` boolean property
2. Adds `titles` array and deprecates `title`, `titleEnglish`, `titleJapanese`, and `titleSynonyms`

### Users

1. Adds external links under `GET /users/{username}/external`
2. Adds external links under `GET /users/{username}/full` as `external`


### Others

- Updates OpenAPI Specs/docs

Related issues/PRs: https://github.com/jikan-me/jikan/pull/444 https://github.com/jikan-me/jikan/pull/426 https://github.com/jikan-me/jikan/issues/407 https://github.com/jikan-me/jikan/issues/373 https://github.com/jikan-me/jikan-rest/issues/254