### PR TITLE
Improves sentry integration and order of exceptions

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -121,10 +121,10 @@ INSIGHTS_MAX_STORE_TIME=172800
 ###
 # Error reporting
 ###
-REPORTING=true
+REPORTING=false
 REPORTING_DRIVER=sentry
 SENTRY_LARAVEL_DSN="https://examplePublicKey@o0.ingest.sentry.io/0"
-SENTRY_TRACES_SAMPLE_RATE=1
+SENTRY_TRACES_SAMPLE_RATE=0.5
 
 ###
 # Endpoints

--- a/app/Exceptions/GithubReport.php
+++ b/app/Exceptions/GithubReport.php
@@ -15,54 +15,54 @@ class GithubReport
     /**
      * @var string
      */
-    private $name;
+    private string $name;
     /**
      * @var string
      */
-    private $code;
+    private string $code;
     /**
      * @var string
      */
-    private $error;
+    private string $error;
 
     /**
      * @var string
      */
-    private $requestUri;
+    private string $requestUri;
     /**
      * @var string
      */
-    private $requestMethod;
+    private string $requestMethod;
 
     /**
      * @var string
      */
-    private $repo;
+    private string $repo;
 
     /**
      * @var string
      */
-    private $trace;
+    private string $trace;
 
     /**
      * @var string
      */
-    private $jikanVersion;
+    private string $jikanVersion;
 
     /**
      * @var string
      */
-    private $redisRunning;
+    private string $redisRunning;
 
     /**
      * @var string
      */
-    private $instanceType;
+    private string $instanceType;
 
     /**
-     * @var
+     * @var string
      */
-    private $phpVersion;
+    private string $phpVersion;
 
     /**
      * @param \Exception $exception

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -117,6 +117,11 @@ if (env('REPORTING') && env('REPORTING_DRIVER') === 'sentry') {
     $app->register(\Sentry\Laravel\ServiceProvider::class);
     // Sentry Performance Monitoring (optional)
     $app->register(\Sentry\Laravel\Tracing\ServiceProvider::class);
+
+    \Sentry\configureScope(function (\Sentry\State\Scope $scope): void {
+        $scope->setTag('rest.jikan.version', env('APP_VERSION'));
+        $scope->setTag('parser.jikan.version', JIKAN_PARSER_VERSION);
+    });
 }
 
 // Guzzle removed as of lumen 8.x

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -8,7 +8,7 @@ return [
     // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
 
     // When left empty or `null` the Laravel environment will be used
-    'environment' => env('SENTRY_ENVIRONMENT'),
+    'environment' => env('APP_ENV'),
 
     'breadcrumbs' => [
         // Capture Laravel logs in breadcrumbs
@@ -53,5 +53,7 @@ return [
     'traces_sample_rate' => (float)(env('SENTRY_TRACES_SAMPLE_RATE', 0.0)),
 
     'controllers_base_namespace' => env('SENTRY_CONTROLLERS_BASE_NAMESPACE', 'App\\Http\\Controllers'),
+
+    'release' => env('APP_VERSION')
 
 ];


### PR DESCRIPTION
This PR improves exception handling and reporting. Right now it's exhausting all sentry transactions (5k in the free tier) within the first week or so. This is because TimeoutException and other unnecessary exceptions are being sent to it as well.

----


- Reduces sentry default sample rate to 50% of errors to prevent flooding
- Sets up sentry-only allowed exceptions (ParserException only added as of this moment) to track parser errors
- Re-arrange the order of exception chain


#### Exception to check in order
1. Redis Connection Exception
2. ParserException
3. BadResponseException (from Parser)
4. TimeoutException (from Parser)
5. ```if ($e instanceof Exception && $e->getMessage() === "Undefined index: url") {```
    a. MAL returns blank pages for some reason sometimes. And this is the generated error
6. HTTPException (Bad REST API requests)
7. Uncaught exception


----

> That sentry thing is awesome, would it be possible to include that link in the generated issues?
https://github.com/jikan-me/jikan/issues/449#issuecomment-1177234032

I don't think that's possible. But I am working on integrating Sentry with GitHub and this repo so sentry should automatically create issues for us if it hits a parser exception.