### PR TITLE
Fixes merging of IDs from mal-id-cache in indexers

### DIFF
--- a/app/Console/Commands/Indexer/AnimeIndexer.php
+++ b/app/Console/Commands/Indexer/AnimeIndexer.php
@@ -19,7 +19,7 @@ class AnimeIndexer extends Command
      *`
      * @var string
      */
-    protected $signature = 'indexer:anime 
+    protected $signature = 'indexer:anime
                             {--failed : Run only entries that failed to index last time}
                             {--resume : Resume from the last position}
                             {--reverse : Start from the end of the array}
@@ -150,7 +150,7 @@ class AnimeIndexer extends Command
             true
         );
 
-        $this->ids = $ids['sfw'] + $ids['nsfw']; // merge
+        $ids = array_merge($ids['sfw'], $ids['nsfw']);
         Storage::put('indexer/anime_mal_id.json', json_encode($this->ids));
 
         return json_decode(Storage::get('indexer/anime_mal_id.json'));

--- a/app/Console/Commands/Indexer/AnimeSweepIndexer.php
+++ b/app/Console/Commands/Indexer/AnimeSweepIndexer.php
@@ -61,9 +61,12 @@ class AnimeSweepIndexer extends Command
 
         foreach ($results as $result) {
             if (!array_key_exists($result['mal_id'], $malIds)) {
+                echo "Removing https://myanimelist.net/anime/".$result['mal_id']."\n";
                 $remove[] = $result['_id'];
             }
         }
+
+        echo "\n\n".count($remove);
 
         echo "Delete removed MAL IDs\n";
         DB::table('anime')->whereIn('_id', $remove)->delete();
@@ -82,7 +85,7 @@ class AnimeSweepIndexer extends Command
             true
         );
 
-        $ids = $ids['sfw'] + $ids['nsfw']; // merge
+        $ids = array_merge($ids['sfw'], $ids['nsfw']);
         Storage::put('indexer/anime_mal_id_sweep.json', json_encode($ids));
 
         return json_decode(Storage::get('indexer/anime_mal_id_sweep.json'));

--- a/app/Console/Commands/Indexer/MangaIndexer.php
+++ b/app/Console/Commands/Indexer/MangaIndexer.php
@@ -19,7 +19,7 @@ class MangaIndexer extends Command
      *`
      * @var string
      */
-    protected $signature = 'indexer:manga 
+    protected $signature = 'indexer:manga
                             {--failed : Run only entries that failed to index last time}
                             {--resume : Resume from the last position}
                             {--reverse : Start from the end of the array}
@@ -150,7 +150,7 @@ class MangaIndexer extends Command
             true
         );
 
-        $this->ids = $ids['sfw'] + $ids['nsfw']; // merge
+        $ids = array_merge($ids['sfw'], $ids['nsfw']);
         Storage::put('indexer/manga_mal_id.json', json_encode($this->ids));
 
         return json_decode(Storage::get('indexer/manga_mal_id.json'));

--- a/app/Console/Commands/Indexer/MangaSweepIndexer.php
+++ b/app/Console/Commands/Indexer/MangaSweepIndexer.php
@@ -82,7 +82,7 @@ class MangaSweepIndexer extends Command
             true
         );
 
-        $ids = $ids['sfw'] + $ids['nsfw']; // merge
+        $ids = array_merge($ids['sfw'], $ids['nsfw']);
         Storage::put('indexer/manga_mal_id_sweep.json', json_encode($ids));
 
         return json_decode(Storage::get('indexer/manga_mal_id_sweep.json'));


### PR DESCRIPTION
For some reason

```php
$ids = $ids['sfw'] + $ids['nsfw']; // merge
```
This does not work. The NSFW array does not get included in the storage output of the next line.

```php
Storage::put('indexer/manga_mal_id_sweep.json', json_encode($ids));
```

No clue why. #justPHPThings

----

This works instead:

```php
$ids = array_merge($ids['sfw'], $ids['nsfw']);
```