### PR TITLE
Added issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -4,8 +4,10 @@ about: Let us know if something is wrong \U0001F914
 title: ''
 labels: 'i: bug, i: needs triage'
 ---
-Make sure to add all the information needed to understand the bug so that someone can help. If the info is missing we'll add the 'Needs more information' label and close the issue until there is enough information.
+Make sure to add all the information needed to understand the bug so that someone can help. If the info is missing we'll add the 'Needs more information' label and close the issue until there is enough information. Additionally it would greatly help us reducing duplicates and we would really appriacte if you could search the existing issues for the problem you are experiencing.
+
 Feel free to delete the template text, but please leave in the questions and answers below.
+
 ## Bug Report
 
 * **What is the current behavior?**

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,28 @@
+---
+name: \U0001F41B Bug report
+about: Let us know if something is wrong \U0001F914
+title: ''
+labels: 'i: bug, i: needs triage'
+---
+Make sure to add all the information needed to understand the bug so that someone can help. If the info is missing we'll add the 'Needs more information' label and close the issue until there is enough information.
+Feel free to delete the template text, but please leave in the questions and answers below.
+## Bug Report
+
+* **What is the current behavior?**
+
+
+
+* **Please provide the steps to reproduce it** usually via the url to the REST API endpoint
+
+
+
+* **What is the expected behavior?**
+
+
+
+* **What is the motivation / use case for changing the behavior?**
+
+
+
+* **Other information / Contextual information** (e.g. detailed explanation, stacktraces, related issues, screenshots, suggestions how to fix, links for us to have context, eg. stackoverflow, discord channel link, etc)
+

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Have an idea?
+title: ''
+labels: 'i: enhancement, i: needs triage'
+assignees: ''
+---
+Feel free to delete parts of the template text, if they are not entirely relevant for your feature request.
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. E.g. I have an issue when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. Add any considered drawbacks.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Teachability, Documentation, Adoption, Migration Strategy**
+If you can, explain how users will be able to use this and benefit from it.

--- a/.github/ISSUE_TEMPLATE/support_question.md
+++ b/.github/ISSUE_TEMPLATE/support_question.md
@@ -1,0 +1,17 @@
+---
+name: "\U0001F917 Support Question"
+about: "If you have a question \U0001F4AC, please check out our discord server!"
+title: ''
+labels: 'i: question, i: needs triage'
+assignees: ''
+---
+
+--------------^ Click "Preview" for a nicer view!
+We primarily use GitHub as an issue tracker; for usage and support questions, please check out these resources below. Thanks! 😁.
+
+---
+
+* Discord: [![Discord Server](https://img.shields.io/discord/460491088004907029.svg?style=flat&logo=discord)](https://discordapp.com/invite/4tvCr36)
+* Have a look at the readme for more information on how to get support:
+  https://github.com/jikan-me/jikan-rest/blob/master/README.md
+* Container usage for self hosters: https://github.com/jikan-me/jikan-rest/blob/master/container_usage.md


### PR DESCRIPTION
Metadata in md files lives at the top, which also causes weird rendering if you preview them through the PR, so ignore that bit.

I used the following reasources:
- https://github.blog/2018-01-25-multiple-issue-and-pull-request-templates/
- https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue
- https://github.com/stevemao/github-issue-templates/
- https://github.com/devspace/awesome-github-templates
- https://github.com/michael-ciniawsky/.github    --> you can see here how this is going to look when someone tries to create a new issue
