### PR TITLE
Fixed comparisons for score parameter ingestion

### DIFF
--- a/app/Http/QueryBuilder/MediaSearchQueryBuilder.php
+++ b/app/Http/QueryBuilder/MediaSearchQueryBuilder.php
@@ -111,21 +111,21 @@ abstract class MediaSearchQueryBuilder extends SearchQueryBuilder
                 ->where('status', $status);
         }
 
-        if ($score !== 0) {
+        if (!is_null($score)) {
             $score = (float)$score;
 
             $builder = $builder
                 ->where('score', '>=', $score);
         }
 
-        if ($min_score !== null) {
+        if (!is_null($min_score)) {
             $min_score = (float)$min_score;
 
             $builder = $builder
                 ->where('score', '>=', $min_score);
         }
 
-        if ($max_score !== null) {
+        if (!is_null($max_score)) {
             $max_score = (float)$max_score;
 
             $builder = $builder


### PR DESCRIPTION
The `score` parameter has an incorrect comparison:
```php
if ($score !== 0) {
}
```
This is prone to bugs.
This PR fixes it, also changes comparisons of nulls to `is_null` function usage.