### PR TITLE
Various hot fixes

### DIFF
--- a/app/Dto/QueryAnimeSchedulesCommand.php
+++ b/app/Dto/QueryAnimeSchedulesCommand.php
@@ -17,6 +17,8 @@ use App\Rules\Attributes\EnumValidation;
 use Illuminate\Http\JsonResponse;
 use Spatie\LaravelData\Attributes\WithCast;
 use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Attributes\MapInputName;
+use Spatie\LaravelData\Attributes\MapOutputName;
 
 /**
  * @implements DataRequest<JsonResponse>
@@ -25,6 +27,11 @@ final class QueryAnimeSchedulesCommand extends Data implements DataRequest
 {
     use HasLimitParameter, HasRequestFingerprint, HasPageParameter, PreparesData, HasSfwParameter, HasKidsParameter, HasUnapprovedParameter, MapsRouteParameters;
 
-    #[WithCast(EnumCast::class, AnimeScheduleFilterEnum::class), EnumValidation(AnimeScheduleFilterEnum::class)]
+    #[
+        WithCast(EnumCast::class, AnimeScheduleFilterEnum::class),
+        EnumValidation(AnimeScheduleFilterEnum::class),
+        MapInputName("filter"),
+        MapOutputName("filter")
+    ]
     public ?AnimeScheduleFilterEnum $dayFilter;
 }

--- a/app/Features/Concerns/ResolvesMediaReviewParams.php
+++ b/app/Features/Concerns/ResolvesMediaReviewParams.php
@@ -13,7 +13,8 @@ trait ResolvesMediaReviewParams
         $sort = $requestParams->get("sort", MediaReviewsSortEnum::mostVoted()->value);
         $spoilers = $requestParams->get("spoilers", false);
         $preliminary = $requestParams->get("preliminary", false);
+        $page = $requestParams->get("page", 1);
 
-        return compact("id", "sort", "spoilers", "preliminary");
+        return compact("id", "sort", "spoilers", "preliminary", "page");
     }
 }

--- a/app/Manga.php
+++ b/app/Manga.php
@@ -77,6 +77,12 @@ class Manga extends JikanApiSearchableModel
     }
 
     /** @noinspection PhpUnused */
+    public function filterByType(\Laravel\Scout\Builder|\Illuminate\Database\Eloquent\Builder $query, MangaTypeEnum $value): \Laravel\Scout\Builder|\Illuminate\Database\Eloquent\Builder
+    {
+        return $query->where("type", $value->label);
+    }
+
+    /** @noinspection PhpUnused */
     public function filterByEndDate(\Laravel\Scout\Builder|\Illuminate\Database\Eloquent\Builder $query, CarbonImmutable $value): \Laravel\Scout\Builder|\Illuminate\Database\Eloquent\Builder
     {
         return $query

--- a/app/Repositories/DefaultAnimeRepository.php
+++ b/app/Repositories/DefaultAnimeRepository.php
@@ -39,7 +39,7 @@ final class DefaultAnimeRepository extends DatabaseRepository implements AnimeRe
         return $this->exceptItemsWithAdultRating()
             ->where("status", AnimeStatusEnum::upcoming()->label)
             ->whereNotNull("rank")
-            ->where("rank", ">", 0)
+            ->where("rank", ">=", 0)
             ->orderBy("rank");
     }
 
@@ -81,7 +81,7 @@ final class DefaultAnimeRepository extends DatabaseRepository implements AnimeRe
     {
         return $this->exceptItemsWithAdultRating()
             ->whereNotNull("rank")
-            ->where("rank", ">", 0)
+            ->where("rank", ">=", 0)
             ->orderBy("rank");
     }
 

--- a/app/Repositories/DefaultAnimeRepository.php
+++ b/app/Repositories/DefaultAnimeRepository.php
@@ -81,7 +81,7 @@ final class DefaultAnimeRepository extends DatabaseRepository implements AnimeRe
     {
         return $this->exceptItemsWithAdultRating()
             ->whereNotNull("rank")
-            ->where("rank", ">=", 0)
+            ->where("rank", ">", 0)
             ->orderBy("rank");
     }
 


### PR DESCRIPTION
- fixed issue with the schedules endpoint where the `filter` parameter didn't work #406 
- fixed issue with the upcoming filter of the `top/anime` endpoint: this is currently an interim solution, it might need more thought, as we want to order the items according to something, as currently the order of items by default is just random.
- fixed #395  - we forgot to add the explicit filter method to the Manga model. 