### PR TITLE
Added fixes for searching and various things

### DIFF
--- a/app/Anime.php
+++ b/app/Anime.php
@@ -381,13 +381,17 @@ class Anime extends JikanApiSearchableModel
     {
         return [
             [
-                "field" => "_text_match",
+                "field" => "_text_match(buckets:" . App::make("jikan-config")->maxResultsPerPage() . ")",
                 "direction" => "desc"
             ],
             [
-                "field" => "members",
-                "direction" => "desc"
+                "field" => "popularity",
+                "direction" => "asc"
             ],
+            [
+                "field" => "rank",
+                "direction" => "asc"
+            ]
         ];
     }
 

--- a/app/Anime.php
+++ b/app/Anime.php
@@ -381,7 +381,7 @@ class Anime extends JikanApiSearchableModel
     {
         return [
             [
-                "field" => "_text_match(buckets:" . App::make("jikan-config")->maxResultsPerPage() . ")",
+                "field" => "_text_match(buckets:" . max_results_per_page() . ")",
                 "direction" => "desc"
             ],
             [

--- a/app/Concerns/ResolvesPaginatorParams.php
+++ b/app/Concerns/ResolvesPaginatorParams.php
@@ -2,11 +2,13 @@
 
 namespace App\Concerns;
 
+use Illuminate\Support\Facades\App;
+
 trait ResolvesPaginatorParams
 {
     private function getPaginatorParams(?int $limit = null, ?int $page = null): array
     {
-        $default_max_results_per_page = env('MAX_RESULTS_PER_PAGE', 25);
+        $default_max_results_per_page = App::make("jikan-config")->maxResultsPerPage();
         $limit = $limit ?? $default_max_results_per_page;
         $page = $page ?? 1;
 

--- a/app/Concerns/ResolvesPaginatorParams.php
+++ b/app/Concerns/ResolvesPaginatorParams.php
@@ -8,7 +8,7 @@ trait ResolvesPaginatorParams
 {
     private function getPaginatorParams(?int $limit = null, ?int $page = null): array
     {
-        $default_max_results_per_page = App::make("jikan-config")->maxResultsPerPage();
+        $default_max_results_per_page = max_results_per_page();
         $limit = $limit ?? $default_max_results_per_page;
         $page = $page ?? 1;
 

--- a/app/Contracts/SearchAnalyticsService.php
+++ b/app/Contracts/SearchAnalyticsService.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Contracts;
+
+use Illuminate\Support\Collection;
+
+interface SearchAnalyticsService
+{
+    public function logSearch(string $searchTerm, int $hitsCount, Collection $hits, string $indexName): void;
+}

--- a/app/Dto/Concerns/PreparesData.php
+++ b/app/Dto/Concerns/PreparesData.php
@@ -20,7 +20,7 @@ trait PreparesData
         // let's always set the limit parameter to the globally configured default value
         if (property_exists(static::class, "limit") && !$properties->has("limit")) {
             /** @noinspection PhpUndefinedFieldInspection */
-            $properties->put("limit", App::make("jikan-config")->maxResultsPerPage(
+            $properties->put("limit", max_results_per_page(
                 property_exists(static::class, "defaultLimit") ? static::$defaultLimit : null));
         }
 

--- a/app/Dto/Concerns/PreparesData.php
+++ b/app/Dto/Concerns/PreparesData.php
@@ -4,6 +4,7 @@ namespace App\Dto\Concerns;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\App;
 use \ReflectionClass;
 use Spatie\LaravelData\Support\DataConfig;
 
@@ -19,8 +20,8 @@ trait PreparesData
         // let's always set the limit parameter to the globally configured default value
         if (property_exists(static::class, "limit") && !$properties->has("limit")) {
             /** @noinspection PhpUndefinedFieldInspection */
-            $properties->put("limit", Env::get("MAX_RESULTS_PER_PAGE",
-                property_exists(static::class, "defaultLimit") ? static::$defaultLimit : 25));
+            $properties->put("limit", App::make("jikan-config")->maxResultsPerPage(
+                property_exists(static::class, "defaultLimit") ? static::$defaultLimit : null));
         }
 
         // we want to cast "true" and "false" string values to boolean before validation, so let's take all properties

--- a/app/Dto/QueryAnimeSchedulesCommand.php
+++ b/app/Dto/QueryAnimeSchedulesCommand.php
@@ -17,7 +17,6 @@ use App\Rules\Attributes\EnumValidation;
 use Illuminate\Http\JsonResponse;
 use Spatie\LaravelData\Attributes\WithCast;
 use Spatie\LaravelData\Data;
-use Spatie\LaravelData\Attributes\MapInputName;
 use Spatie\LaravelData\Attributes\MapOutputName;
 
 /**
@@ -30,7 +29,6 @@ final class QueryAnimeSchedulesCommand extends Data implements DataRequest
     #[
         WithCast(EnumCast::class, AnimeScheduleFilterEnum::class),
         EnumValidation(AnimeScheduleFilterEnum::class),
-        MapInputName("filter"),
         MapOutputName("filter")
     ]
     public ?AnimeScheduleFilterEnum $dayFilter;

--- a/app/Features/QueryUpcomingAnimeSeasonHandler.php
+++ b/app/Features/QueryUpcomingAnimeSeasonHandler.php
@@ -18,6 +18,6 @@ final class QueryUpcomingAnimeSeasonHandler extends QueryAnimeSeasonHandlerBase
 
     protected function getSeasonItems($request, ?AnimeTypeEnum $type): Builder
     {
-        return $this->repository->getUpcomingSeasonItems($type, $request->kids, $request->sfw, $request->unapproved);
+        return $this->repository->getUpcomingSeasonItems($type);
     }
 }

--- a/app/Manga.php
+++ b/app/Manga.php
@@ -298,13 +298,17 @@ class Manga extends JikanApiSearchableModel
     {
         return [
             [
-                "field" => "_text_match",
+                "field" => "_text_match(buckets:" . App::make("jikan-config")->maxResultsPerPage() . ")",
                 "direction" => "desc"
             ],
             [
-                "field" => "members",
-                "direction" => "desc"
+                "field" => "popularity",
+                "direction" => "asc"
             ],
+            [
+                "field" => "rank",
+                "direction" => "asc"
+            ]
         ];
     }
 

--- a/app/Profile.php
+++ b/app/Profile.php
@@ -19,7 +19,7 @@ class Profile extends JikanApiSearchableModel
     protected $fillable = [
         'mal_id', 'username', 'url', 'images', 'last_online', 'gender', 'birthday', 'location',
         'joined', 'anime_stats', 'manga_stats', 'favorites', 'about',
-        'createdAt', 'modifiedAt'
+        'createdAt', 'modifiedAt', 'internal_username'
     ];
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -83,7 +83,9 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(JikanConfig::class, fn() => new JikanConfig(config("jikan")));
-        $this->app->singleton(\App\Contracts\SearchAnalyticsService::class, \App\Services\DefaultSearchAnalyticsService::class);
+        $this->app->singleton(\App\Contracts\SearchAnalyticsService::class,
+            env("APP_ENV") !== "testing" ? \App\Services\DefaultSearchAnalyticsService::class :
+                \App\Services\DummySearchAnalyticsService::class);
         $this->app->alias(JikanConfig::class, "jikan-config");
         // cache options class is used to share the request scope level cache settings
         $this->app->singleton(CacheOptions::class);

--- a/app/Rules/Attributes/MaxLimitWithFallback.php
+++ b/app/Rules/Attributes/MaxLimitWithFallback.php
@@ -5,13 +5,12 @@ namespace App\Rules\Attributes;
 use App\Rules\MaxResultsPerPageRule;
 use Attribute;
 use Spatie\LaravelData\Attributes\Validation\Rule;
-use Illuminate\Support\Facades\App;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class MaxLimitWithFallback extends Rule
 {
     public function __construct()
     {
-        parent::__construct(new MaxResultsPerPageRule(App::make("jikan-config")->maxResultsPerPage()));
+        parent::__construct(new MaxResultsPerPageRule(max_results_per_page()));
     }
 }

--- a/app/Rules/Attributes/MaxLimitWithFallback.php
+++ b/app/Rules/Attributes/MaxLimitWithFallback.php
@@ -5,12 +5,13 @@ namespace App\Rules\Attributes;
 use App\Rules\MaxResultsPerPageRule;
 use Attribute;
 use Spatie\LaravelData\Attributes\Validation\Rule;
+use Illuminate\Support\Facades\App;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class MaxLimitWithFallback extends Rule
 {
     public function __construct()
     {
-        parent::__construct(new MaxResultsPerPageRule());
+        parent::__construct(new MaxResultsPerPageRule(App::make("jikan-config")->maxResultsPerPage()));
     }
 }

--- a/app/Rules/MaxResultsPerPageRule.php
+++ b/app/Rules/MaxResultsPerPageRule.php
@@ -28,7 +28,7 @@ final class MaxResultsPerPageRule implements Rule
             $value = intval($value);
         }
 
-        if ($value > $this->maxResultsPerPage()) {
+        if ($value > max_results_per_page()) {
             return false;
         }
 
@@ -37,11 +37,7 @@ final class MaxResultsPerPageRule implements Rule
 
     public function message(): array|string
     {
-        return "Value {$this->value} is higher than the configured '{$this->maxResultsPerPage()}' max value.";
-    }
-
-    private function maxResultsPerPage(): int
-    {
-        return (int) App::make("jikan-config")->maxResultsPerPage($this->fallbackLimit);
+        $mrpp = max_results_per_page();
+        return "Value {$this->value} is higher than the configured '$mrpp' max value.";
     }
 }

--- a/app/Rules/MaxResultsPerPageRule.php
+++ b/app/Rules/MaxResultsPerPageRule.php
@@ -4,6 +4,7 @@ namespace App\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\App;
 
 final class MaxResultsPerPageRule implements Rule
 {
@@ -41,6 +42,6 @@ final class MaxResultsPerPageRule implements Rule
 
     private function maxResultsPerPage(): int
     {
-        return (int) Env::get("MAX_RESULTS_PER_PAGE", $this->fallbackLimit);
+        return (int) App::make("jikan-config")->maxResultsPerPage($this->fallbackLimit);
     }
 }

--- a/app/SearchMetric.php
+++ b/app/SearchMetric.php
@@ -1,0 +1,121 @@
+<?php
+namespace App;
+use MongoDB\BSON\ObjectId;
+use Laravel\Scout\Builder;
+
+class SearchMetric extends JikanApiSearchableModel
+{
+    protected $table = 'search_metrics';
+
+    protected $appends = ['hits'];
+
+    protected $fillable = ["search_term", "request_count", "hits", "hits_count", "index_name"];
+
+    protected $hidden = ["_id"];
+
+    public function searchableAs(): string
+    {
+        return "jikan_search_metrics";
+    }
+
+    public function toSearchableArray()
+    {
+        return [
+            "id" => $this->_id,
+            "search_term" => $this->search_term,
+            "request_count" => $this->request_count,
+            "hits" => $this->hits,
+            "hits_count" => $this->hits_count,
+            "index_name" => $this->index_name
+        ];
+    }
+
+    public function getCollectionSchema(): array
+    {
+        return [
+            "name" => $this->searchableAs(),
+            "fields" => [
+                [
+                    "name" => "id",
+                    "type" => "string",
+                    "optional" => false
+                ],
+                [
+                    "name" => "search_term",
+                    "type" => "string",
+                    "optional" => false,
+                    "sort" => false,
+                    "infix" => true
+                ],
+                [
+                    "name" => "request_count",
+                    "type" => "int64",
+                    "sort" => true,
+                    "optional" => false,
+                ],
+                [
+                    "name" => "hits",
+                    "type" => "int64[]",
+                    "sort" => false,
+                    "optional" => false,
+                ],
+                [
+                    "name" => "hits_count",
+                    "type" => "int64",
+                    "sort" => true,
+                    "optional" => false,
+                ],
+                [
+                    "name" => "index_name",
+                    "type" => "string",
+                    "sort" => false,
+                    "optional" => false,
+                    "facet" => true
+                ]
+            ]
+        ];
+    }
+
+    public function getTypeSenseQueryByWeights(): string|null
+    {
+        return "1";
+    }
+
+    public function getScoutKey(): mixed
+    {
+        return $this->_id;
+    }
+
+    public function getScoutKeyName(): mixed
+    {
+        return '_id';
+    }
+
+    public function getKeyType(): string
+    {
+        return 'string';
+    }
+
+    public function typesenseQueryBy(): array
+    {
+        return ["search_term"];
+    }
+
+    public function queryScoutModelsByIds(Builder $builder, array $ids): \Laravel\Scout\Builder|\Illuminate\Database\Eloquent\Builder
+    {
+        $query = static::usesSoftDelete()
+            ? $this->withTrashed() : $this->newQuery();
+
+        if ($builder->queryCallback) {
+            call_user_func($builder->queryCallback, $query);
+        }
+
+        $whereIn = in_array($this->getKeyType(), ['int', 'integer']) ?
+            'whereIntegerInRaw' :
+            'whereIn';
+
+        return $query->{$whereIn}(
+            $this->getScoutKeyName(), array_map(fn ($x) => new ObjectId($x), $ids)
+        );
+    }
+}

--- a/app/Services/DefaultSearchAnalyticsService.php
+++ b/app/Services/DefaultSearchAnalyticsService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services;
+use App\SearchMetric;
+use App\Contracts\SearchAnalyticsService;
+use Illuminate\Support\Collection;
+
+
+/**
+ * The default search analytics service implementation, which saves the stats to the database and indexes it in Typesense.
+ * 
+ * By indexing search terms in Typesense we can use it to provide search suggestions of popular searches.
+ * @package App\Services
+ */
+final class DefaultSearchAnalyticsService implements SearchAnalyticsService
+{
+    public function logSearch(string $searchTerm, int $hitsCount, Collection $hits, string $indexName): void
+    {
+        /**
+         * @var \Laravel\Scout\Builder $existingMetrics
+         */
+        $existingMetrics = SearchMetric::search($searchTerm);
+
+        $hitList = $hits->pluck("id")->values()->map(fn($x) => (int)$x)->all();
+
+        if ($existingMetrics->count() > 0) {
+            $metric = $existingMetrics->first();
+            $metric->hits = $hitList;
+            $metric->hits_count = $hitsCount;
+            $metric->request_count = $metric->request_count + 1;
+            $metric->index_name = $indexName;
+            $metric->save();
+        } else {
+            SearchMetric::create([
+                "search_term" => $searchTerm,
+                "request_count" => 1,
+                "hits" => $hitList,
+                "hits_count" => $hitsCount,
+                "index_name" => $indexName
+            ]);
+        }
+    }
+}

--- a/app/Services/DummySearchAnalyticsService.php
+++ b/app/Services/DummySearchAnalyticsService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\SearchAnalyticsService;
+use Illuminate\Support\Collection;
+
+final class DummySearchAnalyticsService implements SearchAnalyticsService
+{
+    public function logSearch(string $searchTerm, int $hitsCount, Collection $hits, string $indexName): void
+    {
+        // noop;
+    }
+}

--- a/app/Services/TypeSenseScoutSearchService.php
+++ b/app/Services/TypeSenseScoutSearchService.php
@@ -39,8 +39,8 @@ class TypeSenseScoutSearchService implements ScoutSearchService
             $options['exhaustive_search'] = env('TYPESENSE_SEARCH_EXHAUSTIVE', "false");
             $options['search_cutoff_ms'] = (int) env('TYPESENSE_SEARCH_CUTOFF_MS', 450);
             // this will be ignored together with exhaustive_search set to "true"
-            $options['drop_tokens_threshold'] = (int) env('TYPESENSE_DROP_TOKENS_THRESHOLD', 1);
-            $options['typo_tokens_threshold'] = (int) env('TYPESENSE_TYPO_TOKENS_THRESHOLD', 1);
+            $options['drop_tokens_threshold'] = (int) env('TYPESENSE_DROP_TOKENS_THRESHOLD', $this->maxItemsPerPage);
+            $options['typo_tokens_threshold'] = (int) env('TYPESENSE_TYPO_TOKENS_THRESHOLD', $this->maxItemsPerPage);
             $options['enable_highlight_v1'] = 'false';
             $options['infix'] = 'fallback';
             // prevent `Could not parse the filter query: unbalanced `&&` operands.` error

--- a/app/Services/TypeSenseScoutSearchService.php
+++ b/app/Services/TypeSenseScoutSearchService.php
@@ -6,11 +6,9 @@ use App\Contracts\Repository;
 use App\JikanApiSearchableModel;
 use App\Support\JikanConfig;
 use Illuminate\Support\Str;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\App;
+use Laravel\Scout\Builder;
 use Typesense\Documents;
 use App\Contracts\SearchAnalyticsService;
-use App\Services\TypesenseCollectionDescriptor;
 
 class TypeSenseScoutSearchService implements ScoutSearchService
 {
@@ -30,9 +28,9 @@ class TypeSenseScoutSearchService implements ScoutSearchService
     /**
      * Executes a search operation via Laravel Scout on the provided model class.
      * @param string $q
-     * @return \Laravel\Scout\Builder
-     * @throws \Http\Client\Exception
-     * @throws \Typesense\Exceptions\TypesenseClientError
+     * @param string|null $orderByField
+     * @param bool $sortDirectionDescending
+     * @return Builder
      */
     public function search(string $q, ?string $orderByField = null,
                            bool $sortDirectionDescending = false): \Laravel\Scout\Builder
@@ -74,7 +72,7 @@ class TypeSenseScoutSearchService implements ScoutSearchService
 
             $results = $documents->search($options);
             $this->recordSearchTelemetry($query, $results);
-            
+
             return $results;
         };
     }
@@ -142,7 +140,7 @@ class TypeSenseScoutSearchService implements ScoutSearchService
         // fixme end
 
         // override ordering field
-        if (!is_null($orderByField) && Arr::has($modelAttrNames, $orderByField)) {
+        if (!is_null($orderByField) && in_array($orderByField, $modelAttrNames)) {
             $options['sort_by'] = "$orderByField:" . ($sortDirectionDescending ? "desc" : "asc") . ",_text_match(buckets:".$this->maxItemsPerPage."):desc";
         }
 

--- a/app/Services/TypeSenseScoutSearchService.php
+++ b/app/Services/TypeSenseScoutSearchService.php
@@ -4,16 +4,19 @@ namespace App\Services;
 
 use App\Contracts\Repository;
 use App\JikanApiSearchableModel;
+use App\Support\JikanConfig;
 use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\App;
 use Typesense\Documents;
 
 class TypeSenseScoutSearchService implements ScoutSearchService
 {
     private int $maxItemsPerPage;
 
-    public function __construct(private readonly Repository $repository)
+    public function __construct(private readonly Repository $repository, JikanConfig $config)
     {
-        $this->maxItemsPerPage = (int) env('MAX_RESULTS_PER_PAGE', 25);
+        $this->maxItemsPerPage = (int) $config->maxResultsPerPage();
         if ($this->maxItemsPerPage > 250) {
             $this->maxItemsPerPage = 250;
         }
@@ -33,11 +36,13 @@ class TypeSenseScoutSearchService implements ScoutSearchService
             // let's enable exhaustive search
             // which will make Typesense consider all variations of prefixes and typo corrections of the words
             // in the query exhaustively, without stopping early when enough results are found.
-            $options['exhaustive_search'] = env('TYPESENSE_SEARCH_EXHAUSTIVE', "true");
+            $options['exhaustive_search'] = env('TYPESENSE_SEARCH_EXHAUSTIVE', "false");
             $options['search_cutoff_ms'] = (int) env('TYPESENSE_SEARCH_CUTOFF_MS', 450);
             // this will be ignored together with exhaustive_search set to "true"
             $options['drop_tokens_threshold'] = (int) env('TYPESENSE_DROP_TOKENS_THRESHOLD', 1);
             $options['typo_tokens_threshold'] = (int) env('TYPESENSE_TYPO_TOKENS_THRESHOLD', 1);
+            $options['enable_highlight_v1'] = 'false';
+            $options['infix'] = 'fallback';
             // prevent `Could not parse the filter query: unbalanced `&&` operands.` error
             // this adds support for typesense v0.24.1
             if (array_key_exists('filter_by', $options) && ($options['filter_by'] === ' && ' || $options['filter_by'] === '&&')) {
@@ -48,6 +53,16 @@ class TypeSenseScoutSearchService implements ScoutSearchService
                 $options['per_page'] = min($this->maxItemsPerPage, 250);
             }
 
+            // skip typo checking for short queries
+            if (strlen($query) <= 3) {
+                $options['num_typos'] = 0;
+                $options['typo_tokens_threshold'] = 0;
+                $options['drop_tokens_threshold'] = 0;
+                $options['exhaustive_search'] = 'false';
+                $options['infix'] = 'off';
+                $options['prefix'] = 'false';
+            }
+ 
             $modelInstance = $this->repository->createEntity();
             // get the weights of the query_by fields, if they are provided by the model.
             if ($modelInstance instanceof JikanApiSearchableModel) {
@@ -69,9 +84,35 @@ class TypeSenseScoutSearchService implements ScoutSearchService
                     $options['sort_by'] = $sortBy;
                 }
 
+                // todo: try to avoid service lookup, resolve things via constructor instead.
+                // this is currently a workaround as the search service resolution in the service provider is complex,
+                // and it gives errors when you try to resolve the Typesense class from the LaraveTypesense driver package.
+                // here we'd like to get all the searchable attributes of the model, so we can override the sort order.
+                // we use these attribute names to validate the incoming field name against them, otherwise ignoring them.  
+                $collectionDescriptor = App::make(TypesenseCollectionDescriptor::class);
+                $modelAttrNames = $collectionDescriptor->getSearchableAttributes($modelInstance);
+
+                // fixme: this shouldn't be here, but it's a quick fix for the time being
+                if ($orderByField === "aired.from") {
+                    $orderByField = "start_date";
+                }
+
+                if ($orderByField === "aired.to") {
+                    $orderByField = "end_date";
+                }
+
+                if ($orderByField === "published.from") {
+                    $orderByField = "start_date";
+                }
+
+                if ($orderByField === "published.to") {
+                    $orderByField = "end_date";
+                }
+                // fixme end
+
                 // override ordering field
-                if (!is_null($orderByField)) {
-                    $options['sort_by'] = "$orderByField:" . ($sortDirectionDescending ? "desc" : "asc") . ",_text_match:desc";
+                if (!is_null($orderByField) && Arr::has($modelAttrNames, $orderByField)) {
+                    $options['sort_by'] = "$orderByField:" . ($sortDirectionDescending ? "desc" : "asc") . ",_text_match(buckets:".$this->maxItemsPerPage."):desc";
                 }
 
                 // override overall sorting direction

--- a/app/Services/TypesenseCollectionDescriptor.php
+++ b/app/Services/TypesenseCollectionDescriptor.php
@@ -1,0 +1,37 @@
+<?php
+namespace App\Services;
+use Typesense\LaravelTypesense\Typesense;
+use App\JikanApiSearchableModel;
+use Typesense\Collection as TypesenseCollection;
+use Illuminate\Support\Collection;
+
+/**
+ * A service which helps to describe a collection in Typesense based on an eloquent model
+ */
+final class TypesenseCollectionDescriptor
+{
+    private readonly Collection $cache;
+
+    public function __construct(private readonly Typesense $typesense)
+    {
+        $this->cache = collect();   
+    }
+
+    public function getSearchableAttributes(JikanApiSearchableModel $model): array
+    {
+        $modelSearchableAs = $model->searchableAs();
+        if ($this->cache->has($modelSearchableAs)) {
+            return $this->cache->get($modelSearchableAs);
+        }
+        /**
+         * @var TypesenseCollection $collection
+         */
+        $collection = $this->typesense->getCollectionIndex($model);
+        $collectionDetails = $collection->retrieve();
+        $fields = collect($collectionDetails["fields"]);
+        $searchableAttributeNames = $fields->pluck("name")->all();
+        $this->cache->put($modelSearchableAs, $searchableAttributeNames);
+
+        return $searchableAttributeNames;
+    }
+}

--- a/app/Support/JikanConfig.php
+++ b/app/Support/JikanConfig.php
@@ -18,12 +18,15 @@ final class JikanConfig
 
     private bool $microCachingEnabled;
 
+    private Collection $config;
+
     public function __construct(array $config)
     {
         $config = collect($config);
         $this->perEndpointCacheTtl = $config->get("per_endpoint_cache_ttl", []);
         $this->defaultCacheExpire = $config->get("default_cache_expire", 0);
         $this->microCachingEnabled = in_array($config->get("micro_caching_enabled", false), [true, 1, "1", "true"]);
+        $this->config = $config;
     }
 
     public function cacheTtlForEndpoint(string $endpoint): ?int
@@ -39,5 +42,10 @@ final class JikanConfig
     public function isMicroCachingEnabled(): bool
     {
         return $this->microCachingEnabled;
+    }
+
+    public function maxResultsPerPage(?int $defaultValue = null): int
+    {
+        return $this->config->get("max_results_per_page", $defaultValue ?? 25);
     }
 }

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -54,3 +54,10 @@ if (!function_exists('to_boolean')) {
     }
 }
 
+
+if (!function_exists('max_results_per_page')) {
+    function max_results_per_page(?int $fallbackLimit = null): int
+    {
+        return app()->make("jikan-config")->maxResultsPerPage($fallbackLimit);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,10 @@
         "phpunit": "@php ./vendor/bin/phpunit --no-coverage",
         "phpunit-cover": "@php ./vendor/bin/phpunit",
         "test": [
-          "@phpunit"
+          "@phpunit --testsuite unit"
+        ],
+        "integration-test": [
+          "@phpunit --testsuite integration"
         ],
         "test-cover": [
           "@phpunit-cover"

--- a/config/jikan.php
+++ b/config/jikan.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'max_results_per_page' => env('MAX_RESULTS_PER_PAGE', 25),
     'micro_caching_enabled' => env('MICROCACHING', false),
     'default_cache_expire' => env('CACHE_DEFAULT_EXPIRE', 86400),
     'per_endpoint_cache_ttl' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -86,7 +86,7 @@ return [
                 'port' => env('PAPERTRAIL_PORT'),
                 'connectionString' => 'tls://'.env('PAPERTRAIL_URL').':'.env('PAPERTRAIL_PORT'),
             ],
-            'processors' => [PsrLogMessageProcessor::class],
+            'processors' => [Monolog\Processor\PsrLogMessageProcessor::class],
         ],
 
         'syslog' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -29,10 +29,7 @@ return [
     |
     */
 
-    'deprecations' => [
-        'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
-        'trace' => false,
-    ],
+    'deprecations' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
 
 
     /*

--- a/database/factories/AnimeFactory.php
+++ b/database/factories/AnimeFactory.php
@@ -68,7 +68,7 @@ class AnimeFactory extends JikanMediaModelFactory
             "synopsis" => "test",
             "approved" => true,
             "background" => "test",
-            "premiered" => $this->faker->randomElement(["Winter", "Spring", "Fall", "Summer"]),
+            "premiered" => $this->faker->randomElement(["Winter", "Spring", "Fall", "Summer"]) . " " . $this->faker->year(),
             "broadcast" => [
                 "day" => "",
                 "time" => "",

--- a/database/factories/ProfileFactory.php
+++ b/database/factories/ProfileFactory.php
@@ -21,6 +21,7 @@ final class ProfileFactory extends JikanModelFactory
         return [
             "mal_id" => $mal_id,
             "username" => $username,
+            "internal_username" => $username,
             "url" => $url,
             "request_hash" => sprintf("request:%s:%s", "users", $this->getItemTestUrl("users", $username)),
             "images" => [

--- a/tests/Integration/MangaSearchEndpointTest.php
+++ b/tests/Integration/MangaSearchEndpointTest.php
@@ -98,9 +98,9 @@ class MangaSearchEndpointTest extends TestCase
     public function genresParameterCombinationsProvider(): array
     {
         return [
-            [["genres" => "1,2"]],
-            [["genres_exclude" => "4,5", "type" => "tv"]],
-            [["genres" => "1,2", "genres_exclude" => "3", "min_score" => 8, "type" => "tv", "status" => "complete", "page" => 1]],
+            "?genres=1,2" => [["genres" => "1,2"]],
+            "?genres_exclude=4,5&type=manga" => [["genres_exclude" => "4,5", "type" => "manga"]],
+            "?genres=1,2&genres_exclude=3&min_score=8&type=manga&status=complete" => [["genres" => "1,2", "genres_exclude" => "3", "min_score" => 8, "type" => "manga", "status" => "complete", "page" => 1]],
         ];
     }
 

--- a/tests/Integration/UserControllerTest.php
+++ b/tests/Integration/UserControllerTest.php
@@ -19,8 +19,10 @@ class UserControllerTest extends TestCase
 
     public function testUserProfile()
     {
+        $username = "nekomata1037";
         Profile::factory()->createOne([
-            "username" => "nekomata1037"
+            "username" => $username,
+            "internal_username" => $username
         ]);
         $this->get('/v4/users/nekomata1037')
             ->seeStatusCode(200)
@@ -46,8 +48,10 @@ class UserControllerTest extends TestCase
 
     public function testUserStatistics()
     {
+        $username = "nekomata1037";
         Profile::factory()->createOne([
-            "username" => "nekomata1037"
+            "username" => $username,
+            "internal_username" => $username
         ]);
         $this->get('/v4/users/nekomata1037/statistics')
             ->seeStatusCode(200)
@@ -83,8 +87,10 @@ class UserControllerTest extends TestCase
 
     public function testUserAbout()
     {
+        $username = "nekomata1037";
         Profile::factory()->createOne([
-            "username" => "nekomata1037"
+            "username" => $username,
+            "internal_username" => $username
         ]);
         $this->get('/v4/users/nekomata1037/about')
             ->seeStatusCode(200)
@@ -95,8 +101,10 @@ class UserControllerTest extends TestCase
 
     public function testUserFavorites()
     {
+        $username = "nekomata1037";
         Profile::factory()->createOne([
-            "username" => "nekomata1037"
+            "username" => $username,
+            "internal_username" => $username
         ]);
         $this->get('/v4/users/nekomata1037/favorites')
             ->seeStatusCode(200)


### PR DESCRIPTION
- Better typesense 0.24.1 support
- Exhaustive search disabled by default
- Added central place for the MAX_RESULTS_PER_PAGE option
  - In the future we should strive for the "options" pattern, where a class represents the configuration options of the app and applies safe defaults in the correct type.
  - Added `max_results_per_page()` helper function as part of this fix.
- Added class for getting searchable attributes of models in typesense
- Added basic search analytics:
  - The default implementation saves the search terms and the first page of hits and hit count in the database, and indexes the search term in Typesense.
  - Indexing the search terms used by users will later help with adding new features. (E.g. search suggestions)
- Fixed tests
- Fixed an issue with the `/v4/schedules/<dayFilter>` request validator.
- Fixed deprecation logger
- Fixed bug with ordering through the search engine. E.g. `?q=searchterm&order_by=score` would not order by `score`, rather by the default sort order.
- Fixed #411 

Exhaustive search disabled means that typesense will eat less system resources, but the number of hits will decrease, but the quality of relevance won't be affected.
I think with earlier versions of typesense we used exhaustive search to have enough hits. However the latest version already returns enough hits with exhaustive search turned off for most of the use cases. Only the `drop_tokens_threshold` and `typo_tokens_threshold` needs to be tweaked, and we can get good enough results I think.

Might fixes these issues:
- #393 
- #401 
- #396 