### PR TITLE
Added alternative titles to search index

### DIFF
--- a/app/Anime.php
+++ b/app/Anime.php
@@ -262,7 +262,11 @@ class Anime extends JikanApiSearchableModel
             'title_english_transformed' => $this->simplifyStringForSearch($this->title_english),
             'title_japanese' => $this->title_japanese,
             'title_japanese_transformed' => $this->simplifyStringForSearch($this->title_japanese),
-            'title_synonyms' => $this->title_synonyms,
+            'title_synonyms' => collect($this->titles ?? [])
+                                    ->filter(fn($v, $k) => !in_array($v["type"], ["Default", "English", "Japanese"]))
+                                    ->pluck("title")
+                                    ->values()
+                                    ->all(),
             'type' => $this->type,
             'source' => $this->source,
             'episodes' => $this->episodes,

--- a/app/Manga.php
+++ b/app/Manga.php
@@ -178,7 +178,11 @@ class Manga extends JikanApiSearchableModel
             'title_english_transformed' => $this->simplifyStringForSearch($this->title_english),
             'title_japanese' => $this->title_japanese,
             'title_japanese_transformed' => $this->simplifyStringForSearch($this->title_japanese),
-            'title_synonyms' => $this->title_synonyms,
+            'title_synonyms' => collect($this->titles ?? [])
+                                    ->filter(fn($v, $k) => !in_array($v["type"], ["Default", "English", "Japanese"]))
+                                    ->pluck("title")
+                                    ->values()
+                                    ->all(),
             'type' => $this->type,
             'chapters' => $this->chapters,
             'volumes' => $this->volumes,


### PR DESCRIPTION
Fixes #235 

By adding this users will be able to search for anime/manga with languages other than Japanese/English.
E.g. Attack on Titan's spanish title: `Ataque a los`
 