### PR TITLE
More search tuning and hotfixes

### DIFF
--- a/app/Anime.php
+++ b/app/Anime.php
@@ -374,7 +374,7 @@ class Anime extends JikanApiSearchableModel
 
     public function getTypeSenseQueryByWeights(): string|null
     {
-        return "2,2,1,1,2,2,1";
+        return "2,2,1,1,3,3,1";
     }
 
     /**
@@ -385,7 +385,7 @@ class Anime extends JikanApiSearchableModel
     {
         return [
             [
-                "field" => "_text_match(buckets:" . max_results_per_page() . ")",
+                "field" => "_text_match(buckets:".text_match_buckets().")",
                 "direction" => "desc"
             ],
             [

--- a/app/Features/AnimeSearchHandler.php
+++ b/app/Features/AnimeSearchHandler.php
@@ -25,14 +25,4 @@ class AnimeSearchHandler extends SearchRequestHandler
     {
         return new AnimeCollection($paginator);
     }
-
-    protected function prepareOrderByParam(Collection $requestData): Collection
-    {
-        if ($requestData->has("q") && !$requestData->has("order_by")) {
-            // default order by should be popularity, as MAL seems to use this trick.
-            $requestData->offsetSet("order_by", AnimeOrderByEnum::popularity());
-        }
-
-        return parent::prepareOrderByParam($requestData);
-    }
 }

--- a/app/Features/MangaSearchHandler.php
+++ b/app/Features/MangaSearchHandler.php
@@ -28,14 +28,4 @@ class MangaSearchHandler extends SearchRequestHandler
     {
         return new MangaCollection($paginator);
     }
-
-    protected function prepareOrderByParam(Collection $requestData): Collection
-    {
-        if ($requestData->has("q") && !$requestData->has("order_by")) {
-            // default order by should be popularity, as MAL seems to use this trick.
-            $requestData->offsetSet("order_by", MangaOrderByEnum::popularity());
-        }
-
-        return parent::prepareOrderByParam($requestData);
-    }
 }

--- a/app/Features/SearchRequestHandler.php
+++ b/app/Features/SearchRequestHandler.php
@@ -48,17 +48,11 @@ abstract class SearchRequestHandler implements RequestHandler
 
     protected function prepareOrderByParam(Collection $requestData): Collection
     {
-        if (!$requestData->has('order_by') || !$requestData->get('order_by') instanceof Enum) {
-            $requestData->offsetSet('order_by', 'mal_id');
-            return $requestData;
-        }
-
-        if ($requestData->has('order_by')) {
+        if ($requestData->has('order_by') && !is_null($requestData->get("order_by"))) {
             $requestData->offsetSet("order_by", $requestData->get("order_by")->label);
             return $requestData;
         }
 
-        $requestData->offsetSet("order_by", 'mal_id');
         return $requestData;
     }
 }

--- a/app/Manga.php
+++ b/app/Manga.php
@@ -291,7 +291,7 @@ class Manga extends JikanApiSearchableModel
 
     public function getTypeSenseQueryByWeights(): string|null
     {
-        return "2,2,1,1,2,2,1";
+        return "2,2,1,1,3,3,1";
     }
 
     /**
@@ -302,7 +302,7 @@ class Manga extends JikanApiSearchableModel
     {
         return [
             [
-                "field" => "_text_match(buckets:" . App::make("jikan-config")->maxResultsPerPage() . ")",
+                "field" => "_text_match(buckets:".text_match_buckets().")",
                 "direction" => "desc"
             ],
             [

--- a/app/Services/TypeSenseScoutSearchService.php
+++ b/app/Services/TypeSenseScoutSearchService.php
@@ -70,8 +70,6 @@ class TypeSenseScoutSearchService implements ScoutSearchService
                 $options = $this->overrideSortingOrder($options, $modelInstance, $orderByField, $sortDirectionDescending);
             }
 
-            dd($options, $orderByField);
-
             $results = $documents->search($options);
             $this->recordSearchTelemetry($query, $results);
 

--- a/app/Support/JikanConfig.php
+++ b/app/Support/JikanConfig.php
@@ -20,13 +20,28 @@ final class JikanConfig
 
     private Collection $config;
 
+    private int $textMatchBuckets;
+
+    private int $typoTokensThreshold;
+
+    private int $dropTokensThreshold;
+
+    private int $searchCutOffMs;
+
+    private string $exhaustiveSearch;
+
     public function __construct(array $config)
     {
         $config = collect($config);
         $this->perEndpointCacheTtl = $config->get("per_endpoint_cache_ttl", []);
         $this->defaultCacheExpire = $config->get("default_cache_expire", 0);
         $this->microCachingEnabled = in_array($config->get("micro_caching_enabled", false), [true, 1, "1", "true"]);
+        $this->textMatchBuckets = $config->get("typesense_options.text_match_buckets", 85);
+        $this->exhaustiveSearch = (string) $config->get("typesense_options.exhaustive_search", "false");
         $this->config = $config;
+        $this->typoTokensThreshold = $config->get("typesense_options.typo_tokens_threshold", $this->maxResultsPerPage());
+        $this->dropTokensThreshold = $config->get("typesense_options.drop_tokens_threshold", $this->maxResultsPerPage());
+        $this->searchCutOffMs = $config->get("typesense_options.search_cutoff_ms", 450);
     }
 
     public function cacheTtlForEndpoint(string $endpoint): ?int
@@ -47,5 +62,35 @@ final class JikanConfig
     public function maxResultsPerPage(?int $defaultValue = null): int
     {
         return $this->config->get("max_results_per_page", $defaultValue ?? 25);
+    }
+
+    public function textMatchBuckets(): int
+    {
+        return $this->textMatchBuckets;
+    }
+
+    public function typoTokensThreshold(): int
+    {
+        return $this->typoTokensThreshold;
+    }
+
+    public function dropTokensThreshold(): int
+    {
+        return $this->dropTokensThreshold;
+    }
+
+    public function exhaustiveSearch(): string
+    {
+        $normalizedValue = strtolower($this->exhaustiveSearch);
+        return match($this->exhaustiveSearch) {
+            "0", "FALSE" => "false",
+            "1", "TRUE" => "true",
+            default => in_array($normalizedValue, ["true", "false"]) ? $normalizedValue : "false"
+        };
+    }
+
+    public function searchCutOffMs(): int
+    {
+        return $this->searchCutOffMs;
     }
 }

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -61,3 +61,10 @@ if (!function_exists('max_results_per_page')) {
         return app()->make("jikan-config")->maxResultsPerPage($fallbackLimit);
     }
 }
+
+if (!function_exists('text_match_buckets')) {
+    function text_match_buckets(): int
+    {
+        return app()->make("jikan-config")->textMatchBuckets();
+    }
+}

--- a/config/jikan.php
+++ b/config/jikan.php
@@ -1,9 +1,16 @@
 <?php
 
 return [
-    'max_results_per_page' => env('MAX_RESULTS_PER_PAGE', 25),
+    'max_results_per_page' => (int) env('MAX_RESULTS_PER_PAGE', 25),
     'micro_caching_enabled' => env('MICROCACHING', false),
     'default_cache_expire' => env('CACHE_DEFAULT_EXPIRE', 86400),
+    'typesense_options' => [
+        'text_match_buckets' => env('TYPESENSE_TEXT_MATCH_BUCKETS', 85),
+        'typo_tokens_threshold' => (int) env('TYPESENSE_TYPO_TOKENS_THRESHOLD'),
+        'drop_tokens_threshold' => (int) env('TYPESENSE_DROP_TOKENS_THRESHOLD'),
+        'search_cutoff_ms' => (int) env('TYPESENSE_SEARCH_CUTOFF_MS', 450),
+        'exhaustive_search' => env('TYPESENSE_ENABLE_EXHAUSTIVE_SEARCH', 'false')
+    ],
     'per_endpoint_cache_ttl' => [
         /**
          * Anime


### PR DESCRIPTION
- Refactored the typesense configuration reading logic.
- Changed the weights for the fields when searching: For some reason the japanese title fields are not considered in the search index when searching with japanese letters and the weight for these fields is same as the english ones. The new weights are now higher for japanese fields.
- Previously we tried to fine tune the search results when there was no `order_by` parameter specified in the request by enforcing a default behaviour which would set a default sorting order, so the hits would look more natural. The override happened on the request handler level, however over time I've added more logic in the typesense search service class and in the model classes to deal with this. Now the request handler level override is removed, and the default behavior when the `order_by` parameter is not specified is going to be to take the text match score of the hits, bucket them by 85 items per bucket, then take the rank and popularity as weights to order the results by.

## Notes
With these changes if you are looking for latest anime with it's full title, you would get more accurate results if you set the `order_by` parameter to `mal_id` and the `sort` parameter to `desc`. Example:
```
https://api.jikan.moe/v4/anime?q=world%20dai%20star&order_by=mal_id&sort=desc
```
This will just increase accuracy, because the popularity score of newly added entries is low, and those matches with partial text matches but higher popularity will be ranked higher in the result. The current logic for the search engine takes populairty and rank as a weight when searching by default when no `order_by` parameter is used.