### PR TITLE
Various improvements and hotfixes 2

### DIFF
--- a/app/Anime.php
+++ b/app/Anime.php
@@ -182,10 +182,14 @@ class Anime extends JikanApiSearchableModel
         }
 
         $producer = (int)$value;
-        return $query
-            ->orWhere('producers.mal_id', $producer)
-            ->orWhere('licensors.mal_id', $producer)
-            ->orWhere('studios.mal_id', $producer);
+        /** @noinspection PhpParamsInspection */
+        return $query->whereRaw([
+            '$or' => [
+                ['producers.mal_id' => $producer],
+                ['licensors.mal_id' => $producer],
+                ['studios.mal_id' => $producer]
+            ]
+        ]);
     }
 
     /** @noinspection PhpUnused */
@@ -195,16 +199,16 @@ class Anime extends JikanApiSearchableModel
             return $query;
         }
 
-        $producers = explode(',', $value);
+        $producers = collect(explode(',', $value))->filter()->toArray();
+        $orFilters = [];
         foreach ($producers as $producer) {
-            if (empty($producer)) {
-                continue;
-            }
-
-            $query = $this->filterByProducer($query, $value);
+            $producer = (int)$producer;
+            $orFilters[] = ['producers.mal_id' => $producer];
+            $orFilters[] = ['licensors.mal_id' => $producer];
+            $orFilters[] = ['studios.mal_id' => $producer];
         }
-
-        return $query;
+        /** @noinspection PhpParamsInspection */
+        return $query->whereRaw(['$or' => $orFilters]);
     }
 
     /** @noinspection PhpUnused */

--- a/app/Dto/QueryAnimeSchedulesCommand.php
+++ b/app/Dto/QueryAnimeSchedulesCommand.php
@@ -28,8 +28,7 @@ final class QueryAnimeSchedulesCommand extends Data implements DataRequest
 
     #[
         WithCast(EnumCast::class, AnimeScheduleFilterEnum::class),
-        EnumValidation(AnimeScheduleFilterEnum::class),
-        MapOutputName("filter")
+        EnumValidation(AnimeScheduleFilterEnum::class)
     ]
-    public ?AnimeScheduleFilterEnum $dayFilter;
+    public ?AnimeScheduleFilterEnum $filter;
 }

--- a/app/Dto/SearchCommand.php
+++ b/app/Dto/SearchCommand.php
@@ -7,7 +7,6 @@ use App\Dto\Concerns\HasLimitParameter;
 use App\Dto\Concerns\HasPageParameter;
 use App\Enums\SortDirection;
 use App\Rules\Attributes\EnumValidation;
-use Spatie\Enum\Laravel\Rules\EnumRule;
 use Spatie\LaravelData\Attributes\Validation\Alpha;
 use Spatie\LaravelData\Attributes\Validation\Max;
 use Spatie\LaravelData\Attributes\Validation\Prohibits;

--- a/app/Enums/AnimeOrderByEnum.php
+++ b/app/Enums/AnimeOrderByEnum.php
@@ -7,14 +7,12 @@ use Spatie\Enum\Laravel\Enum;
 /**
  * @method static self mal_id()
  * @method static self title()
- * @method static self type()
  * @method static self rating()
  * @method static self start_date()
  * @method static self end_date()
  * @method static self episodes()
  * @method static self score()
  * @method static self scored_by()
- * @method static self rank()
  * @method static self popularity()
  * @method static self members()
  * @method static self favorites()
@@ -23,7 +21,7 @@ use Spatie\Enum\Laravel\Enum;
  *   schema="anime_search_query_orderby",
  *   description="Available Anime order_by properties",
  *   type="string",
- *   enum={"mal_id", "title", "type", "rating", "start_date", "end_date", "episodes", "score", "scored_by", "rank", "popularity", "members", "favorites" }
+ *   enum={"mal_id", "title", "start_date", "end_date", "episodes", "score", "scored_by", "rank", "popularity", "members", "favorites" }
  * )
  */
 final class AnimeOrderByEnum extends Enum

--- a/app/Enums/AnimeOrderByEnum.php
+++ b/app/Enums/AnimeOrderByEnum.php
@@ -7,12 +7,12 @@ use Spatie\Enum\Laravel\Enum;
 /**
  * @method static self mal_id()
  * @method static self title()
- * @method static self rating()
  * @method static self start_date()
  * @method static self end_date()
  * @method static self episodes()
  * @method static self score()
  * @method static self scored_by()
+ * @method static self rank()
  * @method static self popularity()
  * @method static self members()
  * @method static self favorites()

--- a/app/Features/QueryAnimeSchedulesHandler.php
+++ b/app/Features/QueryAnimeSchedulesHandler.php
@@ -25,7 +25,7 @@ final class QueryAnimeSchedulesHandler implements RequestHandler
     {
         $requestParams = collect($request->all());
         $limit = $requestParams->get("limit");
-        $results = $this->repository->getCurrentlyAiring($request->dayFilter);
+        $results = $this->repository->getCurrentlyAiring($request->filter);
         // apply sfw, kids and unapproved filters
         /** @noinspection PhpUndefinedMethodInspection */
         $results = $results->filter($requestParams);

--- a/app/Manga.php
+++ b/app/Manga.php
@@ -101,7 +101,7 @@ class Manga extends JikanApiSearchableModel
 
         $magazine = (int)$value;
         return $query
-            ->orWhere('serializations.mal_id', $magazine);
+            ->where('serializations.mal_id', $magazine);
     }
 
     /** @noinspection PhpUnused */
@@ -111,16 +111,14 @@ class Manga extends JikanApiSearchableModel
             return $query;
         }
 
-        $magazines = explode(',', $value);
-        foreach ($magazines as $magazine) {
-            if (empty($magazine)) {
-                continue;
-            }
+        $magazines = collect(explode(',', $value))->filter()->map(fn($x) => (int)$x)->toArray();
 
-            $query = $this->filterByMagazine($query, $value);
-        }
-
-        return $query;
+        /** @noinspection PhpParamsInspection */
+        return $query->whereRaw([
+            "serializations.mal_id" => [
+                '$in' => $magazines
+            ]
+        ]);
     }
 
     /** @noinspection PhpUnused */

--- a/app/Rules/MaxResultsPerPageRule.php
+++ b/app/Rules/MaxResultsPerPageRule.php
@@ -3,8 +3,6 @@
 namespace App\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
-use Illuminate\Support\Env;
-use Illuminate\Support\Facades\App;
 
 final class MaxResultsPerPageRule implements Rule
 {
@@ -37,7 +35,7 @@ final class MaxResultsPerPageRule implements Rule
 
     public function message(): array|string
     {
-        $mrpp = max_results_per_page();
+        $mrpp = max_results_per_page($this->fallbackLimit);
         return "Value {$this->value} is higher than the configured '$mrpp' max value.";
     }
 }

--- a/app/Services/DefaultQueryBuilderService.php
+++ b/app/Services/DefaultQueryBuilderService.php
@@ -24,6 +24,9 @@ final class DefaultQueryBuilderService implements QueryBuilderService
                 ->search($requestParameters->get("q"), $searchEngineOptions["order_by"], $searchEngineOptions["sort_direction_descending"]);
         } else {
             $builder = $this->searchService->setFilterParameters($requestParameters)->query();
+            if (!$requestParameters->has("order_by")) {
+                $builder = $builder->orderBy("mal_id");
+            }
         }
 
         return $builder;

--- a/app/Services/DefaultSearchAnalyticsService.php
+++ b/app/Services/DefaultSearchAnalyticsService.php
@@ -4,11 +4,12 @@ namespace App\Services;
 use App\SearchMetric;
 use App\Contracts\SearchAnalyticsService;
 use Illuminate\Support\Collection;
+use Typesense\Documents;
 
 
 /**
  * The default search analytics service implementation, which saves the stats to the database and indexes it in Typesense.
- * 
+ *
  * By indexing search terms in Typesense we can use it to provide search suggestions of popular searches.
  * @package App\Services
  */
@@ -17,13 +18,22 @@ final class DefaultSearchAnalyticsService implements SearchAnalyticsService
     public function logSearch(string $searchTerm, int $hitsCount, Collection $hits, string $indexName): void
     {
         /**
-         * @var \Laravel\Scout\Builder $existingMetrics
+         * @var Collection $existingMetrics
          */
-        $existingMetrics = SearchMetric::search($searchTerm);
+        $existingMetrics = SearchMetric::search($searchTerm, function (Documents $documents, string $query, array $options) {
+            if (strlen($query) <= 3) {
+                $options['prioritize_token_position'] = 'true';
+            }
+
+            return $documents->search($options);
+        })->take(1)->get();
 
         $hitList = $hits->pluck("id")->values()->map(fn($x) => (int)$x)->all();
 
         if ($existingMetrics->count() > 0) {
+            /**
+             * @var SearchMetric $metric
+             */
             $metric = $existingMetrics->first();
             $metric->hits = $hitList;
             $metric->hits_count = $hitsCount;

--- a/app/Services/TypeSenseScoutSearchService.php
+++ b/app/Services/TypeSenseScoutSearchService.php
@@ -141,7 +141,7 @@ class TypeSenseScoutSearchService implements ScoutSearchService
 
         // override ordering field
         if (!is_null($orderByField) && in_array($orderByField, $modelAttrNames)) {
-            $options['sort_by'] = "$orderByField:" . ($sortDirectionDescending ? "desc" : "asc") . ",_text_match(buckets:".$this->maxItemsPerPage."):desc";
+            $options['sort_by'] = "$orderByField:" . ($sortDirectionDescending ? "desc" : "asc") . ",_text_match(buckets:".$this->jikanConfig->textMatchBuckets()."):desc";
         }
 
         // override overall sorting direction

--- a/app/Support/JikanConfig.php
+++ b/app/Support/JikanConfig.php
@@ -3,6 +3,7 @@
 namespace App\Support;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Arr;
 
 /**
  * Jikan behavior config
@@ -32,16 +33,15 @@ final class JikanConfig
 
     public function __construct(array $config)
     {
-        $config = collect($config);
-        $this->perEndpointCacheTtl = $config->get("per_endpoint_cache_ttl", []);
-        $this->defaultCacheExpire = $config->get("default_cache_expire", 0);
-        $this->microCachingEnabled = in_array($config->get("micro_caching_enabled", false), [true, 1, "1", "true"]);
-        $this->textMatchBuckets = $config->get("typesense_options.text_match_buckets", 85);
-        $this->exhaustiveSearch = (string) $config->get("typesense_options.exhaustive_search", "false");
-        $this->config = $config;
-        $this->typoTokensThreshold = $config->get("typesense_options.typo_tokens_threshold", $this->maxResultsPerPage());
-        $this->dropTokensThreshold = $config->get("typesense_options.drop_tokens_threshold", $this->maxResultsPerPage());
-        $this->searchCutOffMs = $config->get("typesense_options.search_cutoff_ms", 450);
+        $this->perEndpointCacheTtl = Arr::get($config, "per_endpoint_cache_ttl", []);
+        $this->defaultCacheExpire = Arr::get($config, "default_cache_expire", 0);
+        $this->microCachingEnabled = in_array(Arr::get($config, "micro_caching_enabled", false), [true, 1, "1", "true"]);
+        $this->textMatchBuckets = Arr::get($config,"typesense_options.text_match_buckets", 1);
+        $this->exhaustiveSearch = (string) Arr::get($config, "typesense_options.exhaustive_search", "false");
+        $this->config = collect($config);
+        $this->typoTokensThreshold = Arr::get($config, "typesense_options.typo_tokens_threshold") ?? $this->maxResultsPerPage();
+        $this->dropTokensThreshold = Arr::get($config, "typesense_options.drop_tokens_threshold") ?? $this->maxResultsPerPage();
+        $this->searchCutOffMs = Arr::get($config, "typesense_options.search_cutoff_ms", 450);
     }
 
     public function cacheTtlForEndpoint(string $endpoint): ?int
@@ -61,7 +61,7 @@ final class JikanConfig
 
     public function maxResultsPerPage(?int $defaultValue = null): int
     {
-        return $this->config->get("max_results_per_page", $defaultValue ?? 25);
+        return (int) $this->config->get("max_results_per_page", $defaultValue ?? 25);
     }
 
     public function textMatchBuckets(): int

--- a/config/jikan.php
+++ b/config/jikan.php
@@ -1,14 +1,14 @@
 <?php
 
 return [
-    'max_results_per_page' => (int) env('MAX_RESULTS_PER_PAGE', 25),
+    'max_results_per_page' => env('MAX_RESULTS_PER_PAGE', 25),
     'micro_caching_enabled' => env('MICROCACHING', false),
     'default_cache_expire' => env('CACHE_DEFAULT_EXPIRE', 86400),
     'typesense_options' => [
-        'text_match_buckets' => env('TYPESENSE_TEXT_MATCH_BUCKETS', 85),
-        'typo_tokens_threshold' => (int) env('TYPESENSE_TYPO_TOKENS_THRESHOLD'),
-        'drop_tokens_threshold' => (int) env('TYPESENSE_DROP_TOKENS_THRESHOLD'),
-        'search_cutoff_ms' => (int) env('TYPESENSE_SEARCH_CUTOFF_MS', 450),
+        'text_match_buckets' => env('TYPESENSE_TEXT_MATCH_BUCKETS', 1),
+        'typo_tokens_threshold' => env('TYPESENSE_TYPO_TOKENS_THRESHOLD'),
+        'drop_tokens_threshold' => env('TYPESENSE_DROP_TOKENS_THRESHOLD'),
+        'search_cutoff_ms' => env('TYPESENSE_SEARCH_CUTOFF_MS', 450),
         'exhaustive_search' => env('TYPESENSE_ENABLE_EXHAUSTIVE_SEARCH', 'false')
     ],
     'per_endpoint_cache_ttl' => [

--- a/routes/web.v4.php
+++ b/routes/web.v4.php
@@ -269,7 +269,7 @@ $router->group(
     }
 );
 
-$router->get('schedules[/{dayFilter:[A-Za-z]+}]', [
+$router->get('schedules[/{filter:[A-Za-z]+}]', [
     'uses' => 'ScheduleController@main'
 ]);
 


### PR DESCRIPTION
- improved searching with low letter count
- removed the ability to order anime by type and rating
- fixed schedules endpoint's filter parameter yet again
- improved configuration
- fixed filtering anime by producers
- fixed filtering manga by magazines
- fixed search analytics in case of short search terms
- fixed #424 
- fixed #426 
- fixed #423 
- fixed #416 
- fixed #413