### PR TITLE
Fixed bug around non anime/manga search

### DIFF
--- a/app/Character.php
+++ b/app/Character.php
@@ -93,4 +93,9 @@ class Character extends JikanApiSearchableModel
             'name_kanji'
         ];
     }
+
+    public function getTitleAttributeName(): string
+    {
+        return 'name';
+    }
 }

--- a/app/Club.php
+++ b/app/Club.php
@@ -101,6 +101,6 @@ class Club extends JikanApiSearchableModel
 
     public function getTitleAttributeName(): string
     {
-        return "name";
+        return 'name';
     }
 }

--- a/app/Club.php
+++ b/app/Club.php
@@ -98,4 +98,9 @@ class Club extends JikanApiSearchableModel
     {
         return ['name'];
     }
+
+    public function getTitleAttributeName(): string
+    {
+        return "name";
+    }
 }

--- a/app/GenreAnime.php
+++ b/app/GenreAnime.php
@@ -73,4 +73,9 @@ class GenreAnime extends JikanApiSearchableModel
             'name'
         ];
     }
+
+    public function getTitleAttributeName(): string
+    {
+        return 'name';
+    }
 }

--- a/app/GenreManga.php
+++ b/app/GenreManga.php
@@ -72,4 +72,9 @@ class GenreManga extends JikanApiSearchableModel
             'name'
         ];
     }
+
+    public function getTitleAttributeName(): string
+    {
+        return 'name';
+    }
 }

--- a/app/JikanApiSearchableModel.php
+++ b/app/JikanApiSearchableModel.php
@@ -88,4 +88,9 @@ abstract class JikanApiSearchableModel extends JikanApiModel implements Typesens
         }
         return preg_replace("/[^[:alnum:][:space:]]/u", ' ', $val) ?? "";
     }
+
+    public function getTitleAttributeName(): string
+    {
+        return 'title';
+    }
 }

--- a/app/Magazine.php
+++ b/app/Magazine.php
@@ -78,4 +78,9 @@ class Magazine extends JikanApiSearchableModel
             'name'
         ];
     }
+
+    public function getTitleAttributeName(): string
+    {
+        return 'name';
+    }
 }

--- a/app/Person.php
+++ b/app/Person.php
@@ -104,4 +104,9 @@ class Person extends JikanApiSearchableModel
             "alternate_names"
         ];
     }
+
+    public function getTitleAttributeName(): string
+    {
+        return 'name';
+    }
 }

--- a/app/Producers.php
+++ b/app/Producers.php
@@ -80,6 +80,6 @@ class Producers extends JikanApiSearchableModel
 
     public function getTitleAttributeName(): string
     {
-        return "titles";
+        return 'titles';
     }
 }

--- a/app/Producers.php
+++ b/app/Producers.php
@@ -77,4 +77,9 @@ class Producers extends JikanApiSearchableModel
             'titles'
         ];
     }
+
+    public function getTitleAttributeName(): string
+    {
+        return "titles";
+    }
 }

--- a/app/Services/TypeSenseScoutSearchService.php
+++ b/app/Services/TypeSenseScoutSearchService.php
@@ -128,9 +128,9 @@ class TypeSenseScoutSearchService implements ScoutSearchService
                 $sortBy .= ',';
             }
             $sortBy = rtrim($sortBy, ',');
-            $options['sort_by'] = $sortBy;
+            $options["sort_by"] = $sortBy;
         } else if (is_null($sortByFields) && !array_key_exists("sort_by", $options)) {
-            $options['sort_by'] = "_text_match:desc";
+            $options["sort_by"] = "_text_match:desc";
         }
 
         return $options;


### PR DESCRIPTION
Error message screenshot:
![error message](https://cdn.discordapp.com/attachments/732509662280417360/1151402368441790464/image.png "error message being fixed in this pr")

The app has a special logic / optimization for short search terms. When the search term is shorter than 4 characters in length, the app changes the options sent to the Typesense API to improve search results.

In case of all non anime/manga endpoints which allow searching through the search index there is a bug when you try to search with short search terms (shorter than 4 in length) the api returns a 500 error. This is caused by the before mentioned logic being only specific to the anime/manga endpoints.

This PR addresses this issue by adding a default value for the "sort_by" option being sent to Typesense API.