### PR TITLE
Container image release fixes

### DIFF
--- a/.github/workflows/container-image-release.yml
+++ b/.github/workflows/container-image-release.yml
@@ -62,13 +62,16 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: ${{ matrix.platform }}
           # let's use github action cache storage
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # todo: We are building a multi arch image, and because of the OCI standard the labels defined above should go in the annotations too. 
+          # todo: Add "annotations" when the new version hits of this action: https://github.com/docker/build-push-action/pull/992
+          # todo: that way all the fields in packages will be populated, so each version will have proper revision, name, description.
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
@@ -103,7 +106,7 @@ jobs:
 
       - name: Read metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.REGISTRY_IMAGE }}
@@ -116,7 +119,7 @@ jobs:
             org.opencontainers.image.documentation=https://github.com/jikan-me/jikan-rest/blob/master/container_usage.md
             org.opencontainers.image.revision=${{ github.sha }}
           tags: |
-            type=raw,value=${{ inputs.image_tag }}
+            type=raw,value=${{ inputs.image_tag || github.ref_name }}
             type=raw,value=${{ github.ref_type == 'tag' && 'latest' || 'latest-nightly' }}
             type=sha
 
@@ -136,7 +139,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") $(jq -cr '.labels | to_entries | map("--annotation \"\(.key)=\(.value)\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
We are building multi arch images in the github action.  On the packages page of the repo, for each version you see "No description" provided, however the github action already adds that label to the container image. See here: https://github.com/jikan-me/jikan-rest/pkgs/container/jikan-rest/141371328?tag=sha-56f4783

In case of multi arch images the manifest should contain these OCI standard labels in the "annotations" section. This PR adds the defined labels as annotations when creating the image manifest.

Additional changes:
- upgraded versions
- fixed tagging -- the version tag based on the release name/tag was missing before