### PR TITLE
:fire: Hotfix: Page param for animelist/mangalist endpoints is ignored

### DIFF
--- a/app/Features/QueryAnimeListOfUserHandler.php
+++ b/app/Features/QueryAnimeListOfUserHandler.php
@@ -60,7 +60,8 @@ final class QueryAnimeListOfUserHandler extends RequestHandlerWithScraperCache
         $jikanParserRequest = $requestParams->get("jikanParserRequest");
         return $this->scraperService->findList(
             $requestFingerPrint,
-            fn(MalClient $jikan, ?int $page = null) => ["anime" => $jikan->getUserAnimeList($jikanParserRequest)]
+            fn(MalClient $jikan, ?int $page = null) => ["anime" => $jikan->getUserAnimeList($jikanParserRequest)],
+            $requestParams->get("page", 1)
         );
     }
 }

--- a/app/Features/QueryMangaListOfUserHandler.php
+++ b/app/Features/QueryMangaListOfUserHandler.php
@@ -60,7 +60,8 @@ final class QueryMangaListOfUserHandler extends RequestHandlerWithScraperCache
         $jikanParserRequest = $requestParams->get("jikanParserRequest");
         return $this->scraperService->findList(
             $requestFingerPrint,
-            fn(MalClient $jikan, ?int $page = null) => ["anime" => $jikan->getUserMangaList($jikanParserRequest)]
+            fn(MalClient $jikan, ?int $page = null) => ["anime" => $jikan->getUserMangaList($jikanParserRequest)],
+            $requestParams->get("page", 1)
         );
     }
 }


### PR DESCRIPTION
The `?page` parameter should not be ignored in case of the `animelist` and `mangalist` endpoints. (This is only applicable for self-hosters)