### PR TITLE
Fix Userlists: Don't overwrite page parameter

### DIFF
--- a/app/Services/JikanUserListRequestMapperService.php
+++ b/app/Services/JikanUserListRequestMapperService.php
@@ -28,10 +28,6 @@ final class JikanUserListRequestMapperService
             $values["sort"] = $values["sort"] === "asc" ? -1 : 1;
         }
 
-        if (!array_key_exists("page", $values)) {
-            $values["page"] = 1;
-        }
-
         if ($listType->equals(UserListTypeEnum::anime())) {
             $rangeFrom = "airedFrom";
             $rangeTo = "airedTo";


### PR DESCRIPTION
This pull-request depends on #452.

The array from line `20` specifically excludes `page` among other keys.
Additionally, the constructor of both `UserAnimeListRequest` and `UserMangaListRequest` already specify optional values for `page`.
In the return line, the correct page key has previously been overwritten using the values from the `values` array, or at least that's what I think.
It works for me, but please test before merging.