### PR TITLE
Changed cache scope for container image build

### DIFF
--- a/.github/workflows/container-image-release.yml
+++ b/.github/workflows/container-image-release.yml
@@ -67,8 +67,8 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           # let's use github action cache storage
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=buildkit_${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=buildkit_${{ matrix.platform }}
           # todo: We are building a multi arch image, and because of the OCI standard the labels defined above should go in the annotations too. 
           # todo: Add "annotations" when the new version hits of this action: https://github.com/docker/build-push-action/pull/992
           # todo: that way all the fields in packages will be populated, so each version will have proper revision, name, description.


### PR DESCRIPTION
Fixes #457 

I'm not entirely sure if this is going to be the best way to do it, but it worth a shot. The idea here is to have one set of cache elements per matrix build. If we consider the way docker uses cached layers during build, there might no need to include the branch and tag name in the scope value:

1. docker builds the first few layers, which in case of jikan api the php extensions, composer dependencies, and roadrunner.
2. then it takes the files of jikan and adds it to the image

Because of step one is being constant most of the time, it should  work with just the cpu arch as a cache key.

