### PR TITLE
:zap: Added sorting of mal ids when indexing entries

### DIFF
--- a/app/Console/Commands/Indexer/AnimeIndexer.php
+++ b/app/Console/Commands/Indexer/AnimeIndexer.php
@@ -152,6 +152,7 @@ class AnimeIndexer extends Command
         );
 
         $ids = array_merge($ids['sfw'], $ids['nsfw']);
+        sort($ids, SORT_NUMERIC);
         Storage::put('indexer/anime_mal_id.json', json_encode($ids));
 
         return json_decode(Storage::get('indexer/anime_mal_id.json'));

--- a/app/Console/Commands/Indexer/MangaIndexer.php
+++ b/app/Console/Commands/Indexer/MangaIndexer.php
@@ -152,6 +152,7 @@ class MangaIndexer extends Command
         );
 
         $ids = array_merge($ids['sfw'], $ids['nsfw']);
+        sort($ids, SORT_NUMERIC);
         Storage::put('indexer/manga_mal_id.json', json_encode($ids));
 
         return json_decode(Storage::get('indexer/manga_mal_id.json'));


### PR DESCRIPTION
When if you want to get all the most recent entries from MAL with the indexer until a certain point, you would run the indexers with the `--reverse` option, then kill it where you want it to finish. However it doesn't do it in order, because the json data after loaded is not sorted.