### PR TITLE
:ambulance: Fixed missing items issue in seasons endpoint

### DIFF
--- a/app/Repositories/DefaultAnimeRepository.php
+++ b/app/Repositories/DefaultAnimeRepository.php
@@ -131,7 +131,7 @@ final class DefaultAnimeRepository extends DatabaseRepository implements AnimeRe
         $finalFilter = [];
 
         if ($premiered !== null) {
-            $finalFilter["$or"] = [
+            $finalFilter['$or'] = [
                 ["premiered" => $premiered],
                 [
                     "premiered" => null,


### PR DESCRIPTION
I've refactored the `getAiredBetween` method to do a query of "if premiered field  not null query by premiered, otherwise fallback to aired.from and aired.to". This has fixed the issue in my test environment, where I tested whether "Frieren" is the top of the Fall 2023 season, and whether it's not missing.