### PR TITLE
Remove duplicate parameter from "/schedules" path

### DIFF
--- a/app/Http/Controllers/V4DB/ScheduleController.php
+++ b/app/Http/Controllers/V4DB/ScheduleController.php
@@ -13,8 +13,6 @@ class ScheduleController extends Controller
      *     operationId="getSchedules",
      *     tags={"schedules"},
      *
-     *      @OA\Parameter(ref="#/components/parameters/page"),
-     *
      *      @OA\Parameter(
      *          name="filter",
      *          in="query",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2284,9 +2284,6 @@
                 "operationId": "getSchedules",
                 "parameters": [
                     {
-                        "$ref": "#/components/parameters/page"
-                    },
-                    {
                         "name": "filter",
                         "in": "query",
                         "description": "Filter by day",


### PR DESCRIPTION
Found it when I was importing the API to Postman.

![Screenshot (133)](https://github.com/jikan-me/jikan-rest/assets/102664471/0eb5a232-ccf0-4403-8d34-75b91d1d6bdf)
