### PR TITLE
✅ Fixed filtering by producer/magazine on anime/manga search endpoints

### DIFF
--- a/app/Anime.php
+++ b/app/Anime.php
@@ -181,14 +181,11 @@ class Anime extends JikanApiSearchableModel
         }
 
         $producer = (int)$value;
-        /** @noinspection PhpParamsInspection */
-        return $query->whereRaw([
-            '$or' => [
-                ['producers.mal_id' => $producer],
-                ['licensors.mal_id' => $producer],
-                ['studios.mal_id' => $producer]
-            ]
-        ]);
+        return $query->where(function (\Jenssegers\Mongodb\Eloquent\Builder $query) use ($producer) {
+            return $query->where('producers.mal_id', $producer)
+                ->orWhere('licensors.mal_id', $producer)
+                ->orWhere('studios.mal_id', $producer);
+        });
     }
 
     /** @noinspection PhpUnused */
@@ -198,16 +195,24 @@ class Anime extends JikanApiSearchableModel
             return $query;
         }
 
-        $producers = collect(explode(',', $value))->filter()->toArray();
-        $orFilters = [];
-        foreach ($producers as $producer) {
-            $producer = (int)$producer;
-            $orFilters[] = ['producers.mal_id' => $producer];
-            $orFilters[] = ['licensors.mal_id' => $producer];
-            $orFilters[] = ['studios.mal_id' => $producer];
-        }
-        /** @noinspection PhpParamsInspection */
-        return $query->whereRaw(['$or' => $orFilters]);
+        /* @var \Illuminate\Support\Collection $producers */
+        $producers = collect(explode(',', $value))->filter();
+
+        return $query->where(function (\Jenssegers\Mongodb\Eloquent\Builder $query) use ($producers) {
+            $firstProducer = (int)$producers->first();
+            $query = $query->where('producers.mal_id', $firstProducer)
+                ->orWhere('licensors.mal_id', $firstProducer)
+                ->orWhere('studios.mal_id', $firstProducer);
+
+            foreach ($producers->skip(1) as $producer) {
+                $producer = (int)$producer;
+                $query = $query->orWhere('producers.mal_id', $producer)
+                    ->orWhere('licensors.mal_id', $producer)
+                    ->orWhere('studios.mal_id', $producer);
+            }
+
+            return $query;
+        });
     }
 
     /** @noinspection PhpUnused */

--- a/app/Anime.php
+++ b/app/Anime.php
@@ -103,7 +103,6 @@ class Anime extends JikanApiSearchableModel
             || !is_string($premiered)
             || !preg_match('~(Winter|Spring|Summer|Fall|)\s([\d+]{4})~', $premiered)
         ) {
-            Log::warning("Invalid premiered value in Anime model[$this->mal_id]: " . $premiered);
             return null;
         }
 

--- a/app/Manga.php
+++ b/app/Manga.php
@@ -111,14 +111,10 @@ class Manga extends JikanApiSearchableModel
             return $query;
         }
 
+        /** @var \Illuminate\Support\Collection $magazines */
         $magazines = collect(explode(',', $value))->filter()->map(fn($x) => (int)$x)->toArray();
 
-        /** @noinspection PhpParamsInspection */
-        return $query->whereRaw([
-            "serializations.mal_id" => [
-                '$in' => $magazines
-            ]
-        ]);
+        return $query->whereIn("serializations.mal_id", $magazines);
     }
 
     /** @noinspection PhpUnused */

--- a/database/factories/AnimeFactory.php
+++ b/database/factories/AnimeFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 use App\CarbonDateRange;
 use App\Anime;
 use App\Testing\JikanDataGenerator;
+use Illuminate\Support\Collection;
 use MongoDB\BSON\UTCDateTime;
 
 
@@ -138,5 +139,48 @@ class AnimeFactory extends JikanMediaModelFactory
             "modifiedAt" => new UTCDateTime(),
             "request_hash" => sprintf("request:%s:%s", "v4", $this->getItemTestUrl("anime", $mal_id))
         ];
+    }
+
+    protected function getOverridesFromQueryStringParameters(Collection $additionalParams): array
+    {
+        $overrides = parent::getOverridesFromQueryStringParameters($additionalParams);
+
+        if ($additionalParams->has("producers")) {
+            $overrides["producers"] = [];
+            $producerIds = explode(",", $additionalParams["producers"]);
+            foreach ($producerIds as $producerId) {
+                $overrides["producers"][] = [
+                    "mal_id" => (int)$producerId,
+                    "type" => "anime",
+                    "name" => "Producer ${producerId}",
+                    "url" => "https://myanimelist.net/anime/producer/${producerId}/x"
+                ];
+            }
+        }
+
+        return $overrides;
+    }
+
+    protected function getOppositeOverridesFromQueryStringParameters(Collection $additionalParams): array
+    {
+        $overrides = parent::getOppositeOverridesFromQueryStringParameters($additionalParams);
+
+        if ($additionalParams->has("producers")) {
+            $overrides["producers"] = [];
+            $producerIds = explode(",", $additionalParams["producers"]);
+            do {
+                $randomEls = $this->faker->randomElements([11, 60, 89, 54, 32, 22, 108, 65], $this->faker->numberBetween(1, 3));
+            } while (count(array_intersect($randomEls, $producerIds)) > 0);
+            foreach ($randomEls as $producerId) {
+                $overrides["produces"][] = [
+                    "mal_id" => (int)$producerId,
+                    "type" => "anime",
+                    "name" => "Producer ${producerId}",
+                    "url" => "https://myanimelist.net/anime/producer/${producerId}/x"
+                ];
+            }
+        }
+
+        return $overrides;
     }
 }

--- a/database/factories/JikanMediaModelFactory.php
+++ b/database/factories/JikanMediaModelFactory.php
@@ -62,6 +62,8 @@ abstract class JikanMediaModelFactory extends JikanModelFactory implements Media
             return $this->state($this->serializeStateDefinition($this->getStateOverrides($additionalParams, $doOpposite)));
         }
 
+        // we want to generate overrides for each manufactured item, so all of them will call the faker for values,
+        // and they should have their own values, increasing the randomness of the generated data
         /** @noinspection PhpParamsInspection */
         return $this->state(new Sequence(fn(Sequence $_) => $this->serializeStateDefinition($this->getStateOverrides($additionalParams, $doOpposite))));
     }

--- a/database/factories/MangaFactory.php
+++ b/database/factories/MangaFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 use App\CarbonDateRange;
 use App\Testing\JikanDataGenerator;
 use App\Manga;
+use Illuminate\Support\Collection;
 use MongoDB\BSON\UTCDateTime;
 
 class MangaFactory extends JikanMediaModelFactory
@@ -97,5 +98,49 @@ class MangaFactory extends JikanMediaModelFactory
             "modifiedAt" => new UTCDateTime(),
             "request_hash" => sprintf("request:%s:%s", "v4", $this->getItemTestUrl("manga", $mal_id))
         ];
+    }
+
+    protected function getOverridesFromQueryStringParameters(Collection $additionalParams): array
+    {
+        $overrides = parent::getOverridesFromQueryStringParameters($additionalParams);
+
+        if ($additionalParams->has("magazines")) {
+            $overrides["serializations"] = [];
+            $magazineIds = explode(",", $additionalParams["magazines"]);
+            foreach ($magazineIds as $magazineId) {
+                $overrides["serializations"][] = [
+                    "mal_id" => (int)$magazineId,
+                    "type" => "manga",
+                    "name" => "Magazine {$magazineId}",
+                    "url" => "https://myanimelist.net/manga/magazine/{$magazineId}/x"
+                ];
+            }
+        }
+
+        return $overrides;
+    }
+
+    protected function getOppositeOverridesFromQueryStringParameters(Collection $additionalParams): array
+    {
+        $overrides = parent::getOppositeOverridesFromQueryStringParameters($additionalParams);
+
+        if ($additionalParams->has("magazines")) {
+            $overrides["serializations"] = [];
+            $magazineIds = explode(",", $additionalParams["magazines"]);
+            do {
+                $randomEls = $this->faker->randomElements([11, 60, 89, 54, 32, 22, 108, 65], $this->faker->numberBetween(1, 3));
+            } while (count(array_intersect($randomEls, $magazineIds)) > 0);
+
+            foreach ($randomEls as $magazineId) {
+                $overrides["serializations"][] = [
+                    "mal_id" => (int)$magazineId,
+                    "type" => "manga",
+                    "name" => "Magazine {$magazineId}",
+                    "url" => "https://myanimelist.net/manga/magazine/{$magazineId}/x"
+                ];
+            }
+        }
+
+        return $overrides;
     }
 }

--- a/tests/Integration/AnimeSearchEndpointTest.php
+++ b/tests/Integration/AnimeSearchEndpointTest.php
@@ -261,16 +261,16 @@ class AnimeSearchEndpointTest extends TestCase
      */
     public function testSearchByEndDate($params)
     {
-        $overrides = $this->generateFiveSpecificAndTenRandomElementsInDb($params);
+        $this->generateFiveSpecificAndTenRandomElementsInDb($params);
 
         $content = $this->getJsonResponse($params);
 
         $actualEndDate = Carbon::parse(data_get($content, "data.0.aired.to"));
-        $paramEndDate = Carbon::parse($overrides["aired"]["to"]);
+        $paramEndDate = Carbon::parse($params['end_date']);
 
         $this->seeStatusCode(200);
         $this->assertPaginationData(5);
-        $this->assertLessThanOrEqual(0, $actualEndDate->diff($paramEndDate)->days);
+        $this->assertGreaterThanOrEqual(1, $actualEndDate->diff($paramEndDate)->days);
         // we created 5 elements according to parameters, so we expect 5 of them.
         $this->assertCount(5, $content["data"]);
     }

--- a/tests/Integration/AnimeSearchEndpointTest.php
+++ b/tests/Integration/AnimeSearchEndpointTest.php
@@ -138,6 +138,7 @@ class AnimeSearchEndpointTest extends TestCase
             "type = movie" => [["type" => "movie"]],
             "type = ova" => [["type" => "ova"]],
             "type = special" => [["type" => "special"]],
+            "score = 8 and producers = 11" => [["score" => "8", "producers" => "11"]],
         ];
     }
 

--- a/tests/Integration/MangaSearchEndpointTest.php
+++ b/tests/Integration/MangaSearchEndpointTest.php
@@ -243,16 +243,16 @@ class MangaSearchEndpointTest extends TestCase
      */
     public function testSearchByEndDate($params)
     {
-        $overrides = $this->generateFiveSpecificAndTenRandomElementsInDb($params);
+        $this->generateFiveSpecificAndTenRandomElementsInDb($params);
 
         $content = $this->getJsonResponse($params);
 
         $actualEndDate = Carbon::parse(data_get($content, "data.0.published.to"));
-        $paramEndDate = Carbon::parse($overrides["published"]["to"]);
+        $paramEndDate = Carbon::parse($params["end_date"]);
 
         $this->seeStatusCode(200);
         $this->assertPaginationData(5);
-        $this->assertLessThanOrEqual(0, $actualEndDate->diff($paramEndDate)->days);
+        $this->assertGreaterThanOrEqual(1, $actualEndDate->diff($paramEndDate)->days);
         // we created 5 elements according to parameters, so we expect 5 of them.
         $this->assertCount(5, $content["data"]);
     }

--- a/tests/Integration/MangaSearchEndpointTest.php
+++ b/tests/Integration/MangaSearchEndpointTest.php
@@ -128,6 +128,7 @@ class MangaSearchEndpointTest extends TestCase
             [["type" => "novel"]],
             [["type" => "lightnovel"]],
             [["type" => "oneshot"]],
+            [["score" => "8", "magazines" => "83"]]
         ];
     }
 


### PR DESCRIPTION
Fixes #517    
Currently if you search by producer or magazine on anime/manga search endpoints respectively together with other filter parameters, you won't get back any results because the database query for the search was constructed incorrectly.
This PR fixes that problem.

Additional changes:
- Improved model factories to increase the randomness of the generated models.
- Added the model factory state overrides for filters "score", "magazines" and "producers", so `getOverridesFromQueryStringParameters` method will manufacture the correct models when asked with these params.
- Added test for the use case described in #517