### PR TITLE
bug: fix index URL to new username

### DIFF
--- a/COMMANDS.MD
+++ b/COMMANDS.MD
@@ -66,7 +66,7 @@ Example: `cache:method queue`
 Since v4 uses MongoDB as a means to index cache on some endpoints, having a built cache is important since it
 works best for endpoints like search or top.
 
-`Indexer:Anime` uses [https://github.com/seanbreckenridge/mal-id-cache](https://github.com/seanbreckenridge/mal-id-cache) to fetch available MAL IDs and indexes them.
+`Indexer:Anime` uses [https://github.com/purarue/mal-id-cache](https://github.com/purarue/mal-id-cache) to fetch available MAL IDs and indexes them.
 
 This function only needs to be run once. Any entry's cache updating will automatically be taken care of if it's expired, and a client makes a request for that entry.
 
@@ -90,7 +90,7 @@ This translates to running entries that previously failed to index or update, in
 Since v4 uses MongoDB as a means to index cache on some endpoints, having a built cache is important since it
 works best for endpoints like search or top.
 
-`Indexer:Manga` uses [https://github.com/seanbreckenridge/mal-id-cache](https://github.com/seanbreckenridge/mal-id-cache) to fetch available MAL IDs and indexes them.
+`Indexer:Manga` uses [https://github.com/purarue/mal-id-cache](https://github.com/purarue/mal-id-cache) to fetch available MAL IDs and indexes them.
 
 This function only needs to be run once. Any entry's cache updating will automatically be taken care of if it's expired, and a client makes a request for that entry.
 

--- a/README.MD
+++ b/README.MD
@@ -52,7 +52,6 @@ For any additional help, join our [Discord server](http://discord.jikan.moe/).
 | TypeScript | [jikants](https://github.com/Julien-Broyard/jikants) by Julien Broyard<br>[jikan-client](https://github.com/javi11/jikan-client) by Javier Blanco<br>🆕 **(v4)** [jikan-ts](https://github.com/tutkli/jikan-ts) by Clara Castillo |
 | PHP        | [jikan-php](https://github.com/janvernieuwe/jikan-jikanPHP) by Jan Vernieuwe |
 | .NET       | 🆕 **(v4)** [Jikan.net](https://github.com/Ervie/jikan.net) by Ervie |
-| Elixir     | [JikanEx](https://github.com/seanbreckenridge/jikan_ex) by Sean Breckenridge |
 | Go         | 🆕 **(v4)** [jikan-go](https://github.com/darenliang/jikan-go) by Daren Liang<br>[jikan2go](https://github.com/nokusukun/jikan2go) by nokusukun |
 | Ruby       | [Jikan.rb](https://github.com/Zerocchi/jikan.rb) by Zerocchi |
 | Dart       | [jikan-dart](https://github.com/charafau/jikan-dart) by Rafal Wachol |

--- a/app/Console/Commands/Indexer/AnimeIndexer.php
+++ b/app/Console/Commands/Indexer/AnimeIndexer.php
@@ -67,7 +67,7 @@ class AnimeIndexer extends Command
         $index = (int)$index;
         $delay = (int)$delay;
 
-        $this->info("Info: AnimeIndexer uses seanbreckenridge/mal-id-cache fetch available MAL IDs and updates/indexes them\n\n");
+        $this->info("Info: AnimeIndexer uses purarue/mal-id-cache fetch available MAL IDs and updates/indexes them\n\n");
 
         if ($failed && Storage::exists('indexer/indexer_anime.save')) {
             $this->ids = $this->loadFailedMalIds();
@@ -140,14 +140,14 @@ class AnimeIndexer extends Command
 
     /**
      * @return array
-     * @url https://github.com/seanbreckenridge/mal-id-cache
+     * @url https://github.com/purarue/mal-id-cache
      */
     private function fetchMalIds() : array
     {
-        $this->info("Fetching MAL ID Cache https://raw.githubusercontent.com/seanbreckenridge/mal-id-cache/master/cache/anime_cache.json...\n");
+        $this->info("Fetching MAL ID Cache https://raw.githubusercontent.com/purarue/mal-id-cache/master/cache/anime_cache.json...\n");
 
         $ids = json_decode(
-            file_get_contents('https://raw.githubusercontent.com/seanbreckenridge/mal-id-cache/master/cache/anime_cache.json'),
+            file_get_contents('https://raw.githubusercontent.com/purarue/mal-id-cache/master/cache/anime_cache.json'),
             true
         );
 

--- a/app/Console/Commands/Indexer/AnimeSweepIndexer.php
+++ b/app/Console/Commands/Indexer/AnimeSweepIndexer.php
@@ -74,14 +74,14 @@ class AnimeSweepIndexer extends Command
 
     /**
      * @return array
-     * @url https://github.com/seanbreckenridge/mal-id-cache
+     * @url https://github.com/purarue/mal-id-cache
      */
     private function fetchMalIds(): array
     {
-        $this->info("Fetching MAL ID Cache https://raw.githubusercontent.com/seanbreckenridge/mal-id-cache/master/cache/anime_cache.json...\n");
+        $this->info("Fetching MAL ID Cache https://raw.githubusercontent.com/purarue/mal-id-cache/master/cache/anime_cache.json...\n");
 
         $ids = json_decode(
-            file_get_contents('https://raw.githubusercontent.com/seanbreckenridge/mal-id-cache/master/cache/anime_cache.json'),
+            file_get_contents('https://raw.githubusercontent.com/purarue/mal-id-cache/master/cache/anime_cache.json'),
             true
         );
 

--- a/app/Console/Commands/Indexer/MangaIndexer.php
+++ b/app/Console/Commands/Indexer/MangaIndexer.php
@@ -67,7 +67,7 @@ class MangaIndexer extends Command
         $index = (int)$index;
         $delay = (int)$delay;
 
-        $this->info("Info: MangaIndexer uses seanbreckenridge/mal-id-cache fetch available MAL IDs and updates/indexes them\n\n");
+        $this->info("Info: MangaIndexer uses purarue/mal-id-cache fetch available MAL IDs and updates/indexes them\n\n");
 
         if ($failed && Storage::exists('indexer/indexer_manga.save')) {
             $this->ids = $this->loadFailedMalIds();
@@ -140,14 +140,14 @@ class MangaIndexer extends Command
 
     /**
      * @return array
-     * @url https://github.com/seanbreckenridge/mal-id-cache
+     * @url https://github.com/purarue/mal-id-cache
      */
     private function fetchMalIds() : array
     {
-        $this->info("Fetching MAL ID Cache https://raw.githubusercontent.com/seanbreckenridge/mal-id-cache/master/cache/manga_cache.json...\n");
+        $this->info("Fetching MAL ID Cache https://raw.githubusercontent.com/purarue/mal-id-cache/master/cache/manga_cache.json...\n");
 
         $ids = json_decode(
-            file_get_contents('https://raw.githubusercontent.com/seanbreckenridge/mal-id-cache/master/cache/manga_cache.json'),
+            file_get_contents('https://raw.githubusercontent.com/purarue/mal-id-cache/master/cache/manga_cache.json'),
             true
         );
 

--- a/app/Console/Commands/Indexer/MangaSweepIndexer.php
+++ b/app/Console/Commands/Indexer/MangaSweepIndexer.php
@@ -71,14 +71,14 @@ class MangaSweepIndexer extends Command
 
     /**
      * @return array
-     * @url https://github.com/seanbreckenridge/mal-id-cache
+     * @url https://github.com/purarue/mal-id-cache
      */
     private function fetchMalIds(): array
     {
-        $this->info("Fetching MAL ID Cache https://raw.githubusercontent.com/seanbreckenridge/mal-id-cache/master/cache/manga_cache.json...\n");
+        $this->info("Fetching MAL ID Cache https://raw.githubusercontent.com/purarue/mal-id-cache/master/cache/manga_cache.json...\n");
 
         $ids = json_decode(
-            file_get_contents('https://raw.githubusercontent.com/seanbreckenridge/mal-id-cache/master/cache/manga_cache.json'),
+            file_get_contents('https://raw.githubusercontent.com/purarue/mal-id-cache/master/cache/manga_cache.json'),
             true
         );
 


### PR DESCRIPTION
Hey, maintainer of the mal-id-cache ID file.

my username was updated from the old URL, it seems that GitHub is redirecting the URL (for now), but don't know how long that lasts.

So, thought I would just PR a fix for it

Also removed the elixir wrapper for the same reason described https://github.com/jikan-me/jikan/pull/565