### PR TITLE
:tada: Added incremental indexer command

### DIFF
--- a/COMMANDS.MD
+++ b/COMMANDS.MD
@@ -14,6 +14,7 @@ For an entire list of commands, you can run `php artisan list`
 - [Indexer](#indexer)
     - [Anime](#indexer-anime)
     - [Manga](#indexer-manga)
+    - [Incremental](#indexer-incremental)
 
 ## Commands
 

--- a/COMMANDS.MD
+++ b/COMMANDS.MD
@@ -14,14 +14,14 @@ For an entire list of commands, you can run `php artisan list`
 - [Indexer](#indexer)
     - [Anime](#indexer-anime)
     - [Manga](#indexer-manga)
-  
+
 ## Commands
 
 ### Serve
 Command: `serve`
 Example: `php artisan serve`
 
-Serve the application on the PHP development server 
+Serve the application on the PHP development server
 
 ### Queue
 
@@ -98,7 +98,7 @@ This function only needs to be run once. Any entry's cache updating will automat
 
 Command:
 ```
-indexer:anime
+indexer:manga
     {--failed : Run only entries that failed to index last time}
     {--resume : Resume from the last position}
     {--reverse : Start from the end of the array}
@@ -109,3 +109,16 @@ indexer:anime
 Example: `indexer:manga`
 
 This simply translates to running the indexer without any additional configuration.
+
+#### Indexer: Incremental
+Incrementally indexes media entries from MAL.
+This command will compare the latest version of MAL ids from the [mal_id_cache](https://github.com/purarue/mal-id-cache)
+github repository and compares them with the downloaded ids from the previous run. If no ids found from the previous run, a full indexing session is started.
+
+Command:
+```
+indexer:incremental {mediaType*}
+    {--failed : Run only entries that failed to index last time}
+    {--resume : Resume from the last position}
+    {--delay=3 : Set a delay between requests}
+```

--- a/app/Console/Commands/Indexer/AnimeIndexer.php
+++ b/app/Console/Commands/Indexer/AnimeIndexer.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands\Indexer;
 
-use App\Exceptions\Console\CommandAlreadyRunningException;
 use App\Exceptions\Console\FileNotFoundException;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;

--- a/app/Console/Commands/Indexer/IncrementalIndexer.php
+++ b/app/Console/Commands/Indexer/IncrementalIndexer.php
@@ -26,7 +26,7 @@ class IncrementalIndexer extends Command
     protected function promptForMissingArgumentsUsing(): array
     {
         return [
-            'mediaType' => ['The media type to index.', 'Valid values: anime, manga, character, people']
+            'mediaType' => ['The media type to index.', 'Valid values: anime, manga, characters, people']
         ];
     }
 
@@ -123,7 +123,7 @@ class IncrementalIndexer extends Command
 
             $id = $ids[$index];
 
-            $url = env('APP_URL') . "/v4/anime/$id";
+            $url = env('APP_URL') . "/v4/$mediaType/$id";
             $this->info("Indexing/Updating " . ($i + 1) . "/$idCount $url [MAL ID: $id]");
 
             try
@@ -171,7 +171,7 @@ class IncrementalIndexer extends Command
                 'failed' => $this->option('failed') ?? false
             ],
             [
-                'mediaType' => 'required|in:anime,manga,character,people',
+                'mediaType' => 'required|in:anime,manga,characters,people',
                 'delay' => 'integer|min:1',
                 'resume' => 'bool|prohibited_with:failed',
                 'failed' => 'bool|prohibited_with:resume'

--- a/app/Console/Commands/Indexer/IncrementalIndexer.php
+++ b/app/Console/Commands/Indexer/IncrementalIndexer.php
@@ -26,7 +26,7 @@ class IncrementalIndexer extends Command
     protected function promptForMissingArgumentsUsing(): array
     {
         return [
-            'mediaType' => ['The media type to index.', 'Valid values: anime, manga, characters, people']
+            'mediaType' => ['The media type to index.', 'Valid values: anime, manga']
         ];
     }
 
@@ -171,7 +171,7 @@ class IncrementalIndexer extends Command
                 'failed' => $this->option('failed') ?? false
             ],
             [
-                'mediaType' => 'required|in:anime,manga,characters,people',
+                'mediaType' => 'required|in:anime,manga',
                 'delay' => 'integer|min:1',
                 'resume' => 'bool|prohibited_with:failed',
                 'failed' => 'bool|prohibited_with:resume'

--- a/app/Console/Commands/Indexer/IncrementalIndexer.php
+++ b/app/Console/Commands/Indexer/IncrementalIndexer.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Console\Commands\Indexer;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+
+class IncrementalIndexer extends Command
+{
+    /**
+     * @var bool
+     */
+    private bool $cancelled = false;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'indexer:incremental {mediaType*}
+    {--delay=3 : Set a delay between requests}
+    {--resume : Resume from the last position}
+    {--failed : Run only entries that failed to index last time}';
+
+    protected function promptForMissingArgumentsUsing(): array
+    {
+        return [
+            'mediaType' => ['The media type to index.', 'Valid values: anime, manga, character, people']
+        ];
+    }
+
+    public function handle(): int
+    {
+        $validator = Validator::make(
+            [
+                'mediaType' => $this->argument('mediaType'),
+                'delay' => $this->option('delay'),
+                'resume' => $this->option('resume') ?? false,
+                'failed' => $this->option('failed') ?? false
+            ],
+            [
+                'mediaType' => 'required|in:anime,manga,character,people',
+                'delay' => 'integer|min:1',
+                'resume' => 'bool|prohibited_with:failed',
+                'failed' => 'bool|prohibited_with:resume'
+            ]
+        );
+
+        if ($validator->fails()) {
+            $this->error($validator->errors()->toJson());
+            return 1;
+        }
+
+        $this->trap(SIGTERM, fn () => $this->cancelled = true);
+
+        $resume = $this->option('resume') ?? false;
+        $onlyFailed = $this->option('failed') ?? false;
+        $existingIdsHash = "";
+        $existingIdsRaw = "";
+        /**
+         * @var $mediaTypes array
+         */
+        $mediaTypes = $this->argument("mediaType");
+
+        foreach ($mediaTypes as $mediaType)
+        {
+            $idsToFetch = [];
+            $failedIds = [];
+            $success = [];
+
+            if ($onlyFailed && Storage::exists("indexer/incremental/{$mediaType}_failed.json"))
+            {
+                $idsToFetch["sfw"] = json_decode(Storage::get("indexer/incremental/{$mediaType}_failed.json"));
+            }
+            else
+            {
+                if (Storage::exists("indexer/incremental/$mediaType.json"))
+                {
+                    $existingIdsRaw = Storage::get("indexer/incremental/$mediaType.json");
+                    $existingIdsHash = sha1($existingIdsRaw);
+                }
+
+                if ($this->cancelled)
+                {
+                    return 127;
+                }
+
+                $newIdsRaw = file_get_contents("https://raw.githubusercontent.com/purarue/mal-id-cache/master/cache/${mediaType}_cache.json");
+                $newIdsHash = sha1($newIdsRaw);
+
+                /** @noinspection PhpConditionAlreadyCheckedInspection */
+                if ($this->cancelled)
+                {
+                    return 127;
+                }
+
+                if ($newIdsHash !== $existingIdsHash)
+                {
+                    $newIds = json_decode($newIdsRaw, true);
+                    $existingIds = json_decode($existingIdsRaw, true);
+
+                    if (is_null($existingIds) || count($existingIds) === 0)
+                    {
+                        $idsToFetch = $newIds;
+                    }
+                    else
+                    {
+                        foreach (["sfw", "nsfw"] as $t)
+                        {
+                            $idsToFetch[$t] = array_diff($existingIds[$t], $newIds[$t]);
+                        }
+                    }
+
+                    Storage::put("indexer/incremental/$mediaType.json.tmp", $newIdsRaw);
+                }
+            }
+
+            $idCount = count($idsToFetch);
+            if ($idCount > 0)
+            {
+                $index = 0;
+                if ($resume && Storage::exists("indexer/incremental/{$mediaType}_resume.save"))
+                {
+                    $index = (int)Storage::get("indexer/incremental/{$mediaType}_resume.save");
+                    $this->info("Resuming from index: $index");
+                }
+
+                if ($index > 0 && !isset($this->ids[$index])) {
+                    $index = 0;
+                    $this->warn('Invalid index; set back to 0');
+                }
+
+                Storage::put("indexer/incremental/{$mediaType}_resume.save", 0);
+
+                $this->info("$idCount $mediaType entries available");
+                $ids = array_merge($idsToFetch['sfw'], $idsToFetch['nsfw']);
+                for ($i = $index; $i <= ($idCount - 1); $i++)
+                {
+                    if ($this->cancelled)
+                    {
+                        return 127;
+                    }
+
+                    $id = $ids[$index];
+
+                    $url = env('APP_URL') . "/v4/anime/$id";
+                    $this->info("Indexing/Updating " . ($i + 1) . "/$idCount $url [MAL ID: $id]");
+
+                    try
+                    {
+                        $response = json_decode(file_get_contents($url), true);
+                        if (isset($response['error']) && $response['status'] != 404)
+                        {
+                            $this->error("[SKIPPED] Failed to fetch $url - {$response['error']}");
+                        }
+                    }
+                    catch (\Exception)
+                    {
+                        $this->warn("[SKIPPED] Failed to fetch $url");
+                        $failedIds[] = $id;
+                        Storage::put("indexer/incremental/$mediaType.failed", json_encode($failedIds));
+                    }
+
+                    $success[] = $id;
+                    Storage::put("indexer/incremental/{$mediaType}_resume.save", $index);
+                }
+
+                Storage::delete("indexer/incremental/{$mediaType}_resume.save");
+                $this->info("--- Indexing of $mediaType is complete.");
+                $this->info(count($success) . ' entries indexed or updated.');
+                if (count($failedIds) > 0)
+                {
+                    $this->info(count($failedIds) . ' entries failed to index or update. Re-run with --failed to requeue failed entries only.');
+                }
+                // finalize the latest state
+                Storage::move("indexer/incremental/$mediaType.json.tmp", "indexer/incremental/$mediaType.json");
+            }
+        }
+
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,7 +24,8 @@ class Kernel extends ConsoleKernel
         Indexer\GenreIndexer::class,
         Indexer\ProducersIndexer::class,
         Indexer\AnimeSweepIndexer::class,
-        Indexer\MangaSweepIndexer::class
+        Indexer\MangaSweepIndexer::class,
+        Indexer\IncrementalIndexer::class
     ];
 
     /**

--- a/app/Features/QuerySpecificAnimeSeasonHandler.php
+++ b/app/Features/QuerySpecificAnimeSeasonHandler.php
@@ -3,8 +3,6 @@
 namespace App\Features;
 
 use App\Dto\QuerySpecificAnimeSeasonCommand;
-use App\Enums\AnimeSeasonEnum;
-use App\Enums\AnimeStatusEnum;
 use App\Enums\AnimeTypeEnum;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Support\Carbon;

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": "^8.1",
         "ext-json": "*",
         "ext-mongodb": "*",
+        "ext-pcntl": "*",
         "amphp/http-client": "^4.6",
         "danielmewes/php-rql": "dev-master",
         "darkaonline/swagger-lume": "^9.0",

--- a/container-setup.sh
+++ b/container-setup.sh
@@ -34,7 +34,7 @@ display_help() {
   echo "stop                   Stop Jikan API"
   echo "validate-prereqs       Validate pre-reqs installed (docker, docker-compose)"
   echo "execute-indexers       Execute the indexers, which will scrape and index data from MAL. (Notice: This can take days)"
-  echo "index-incrementally    Executes the incremental indexers for each media type. (anime, manga, character, people)"
+  echo "index-incrementally    Executes the incremental indexers for each media type. (anime, manga, characters, people)"
   echo ""
 }
 

--- a/container-setup.sh
+++ b/container-setup.sh
@@ -34,6 +34,7 @@ display_help() {
   echo "stop                   Stop Jikan API"
   echo "validate-prereqs       Validate pre-reqs installed (docker, docker-compose)"
   echo "execute-indexers       Execute the indexers, which will scrape and index data from MAL. (Notice: This can take days)"
+  echo "index-incrementally    Executes the incremental indexers for each media type. (anime, manga, character, people)"
   echo ""
 }
 
@@ -168,6 +169,10 @@ case "$1" in
       $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:producers
       echo "Indexing done!"
       ;;
+   "index-incrementally")
+      echo "Indexing..."
+      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:incremental anime manga character people
+      echo "Indexing done!"
    *)
       echo "No command specified, displaying help"
       display_help

--- a/container-setup.sh
+++ b/container-setup.sh
@@ -34,7 +34,7 @@ display_help() {
   echo "stop                   Stop Jikan API"
   echo "validate-prereqs       Validate pre-reqs installed (docker, docker-compose)"
   echo "execute-indexers       Execute the indexers, which will scrape and index data from MAL. (Notice: This can take days)"
-  echo "index-incrementally    Executes the incremental indexers for each media type. (anime, manga, characters, people)"
+  echo "index-incrementally    Executes the incremental indexers for each media type. (anime, manga)"
   echo ""
 }
 
@@ -171,7 +171,7 @@ case "$1" in
       ;;
    "index-incrementally")
       echo "Indexing..."
-      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:incremental anime manga character people
+      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:incremental anime manga
       echo "Indexing done!"
    *)
       echo "No command specified, displaying help"

--- a/container_usage.md
+++ b/container_usage.md
@@ -16,6 +16,9 @@ This will:
 > **Note**: The script supports both `docker` and `podman`. In case of `podman` please bare in mind that sometimes the container name resolution doesn't work on the container network. 
 > In those cases you might have to install `aardvark-dns` package. On `Arch Linux` podman uses `netavark` network by default (in 2023) so you will need to install the before mentioned package.
 
+> **Note 2**: The script will start the jikan API, but if you start it for the first  time, it won't have any data in it!
+> You will have to run the indexers through artisan to have data. See ["Running the indexer with the script"](#running-the-indexer-with-the-script) section.
+
 The script has the following prerequisites and will notify you if these are not present:
 
 - git
@@ -36,6 +39,7 @@ start                  Start Jikan API (mongodb, typesense, redis, jikan-api wor
 stop                   Stop Jikan API
 validate-prereqs       Validate pre-reqs installed (docker, docker-compose)
 execute-indexers       Execute the indexers, which will scrape and index data from MAL. (Notice: This can take days)
+index-incrementally    Executes the incremental indexers for each media type. (anime, manga, character, people)
 ```
 
 ### Running the indexer with the script

--- a/container_usage.md
+++ b/container_usage.md
@@ -39,7 +39,7 @@ start                  Start Jikan API (mongodb, typesense, redis, jikan-api wor
 stop                   Stop Jikan API
 validate-prereqs       Validate pre-reqs installed (docker, docker-compose)
 execute-indexers       Execute the indexers, which will scrape and index data from MAL. (Notice: This can take days)
-index-incrementally    Executes the incremental indexers for each media type. (anime, manga, characters, people)
+index-incrementally    Executes the incremental indexers for each media type. (anime, manga)
 ```
 
 ### Running the indexer with the script

--- a/container_usage.md
+++ b/container_usage.md
@@ -39,7 +39,7 @@ start                  Start Jikan API (mongodb, typesense, redis, jikan-api wor
 stop                   Stop Jikan API
 validate-prereqs       Validate pre-reqs installed (docker, docker-compose)
 execute-indexers       Execute the indexers, which will scrape and index data from MAL. (Notice: This can take days)
-index-incrementally    Executes the incremental indexers for each media type. (anime, manga, character, people)
+index-incrementally    Executes the incremental indexers for each media type. (anime, manga, characters, people)
 ```
 
 ### Running the indexer with the script


### PR DESCRIPTION
Currently none of the indexing artisan commands can do incremental indexing. So far we relied on the season and schedule indexer (or full indexing in reverse order), but in case of self-hosted setups that's insufficient, the new entries from MAL never get imported. Not to mention manga entries.
This PR adds a new artisan command: `indexer:incremental`. This command will compare the latest version of MAL ids from the [mal_id_cache](https://github.com/purarue/mal-id-cache) github repository and compares them with the downloaded ids from the previous run. If no ids found from the previous run, a full indexing session is started.

Usage:

```
php artisan indexer:incremental anime manga
```

The first argument is an array, and it's required. You can also just run it with one media type to index:

```
php artisan indexer:incremental anime
```

You can also resume with `--resume` flag if you cancelled it. The command handles the `SIGTERM` singal as well to gracefully stop.