### PR TITLE
Use docker compose instead of docker-compose in container-setup script

### DIFF
--- a/container-setup.sh
+++ b/container-setup.sh
@@ -8,13 +8,12 @@ if [ -x "$(command -v git)" ]; then
   # check if we have checked out a tag or not
   if ! git symbolic-ref HEAD &>/dev/null; then
     # if a tag is checked out then use the tag name as the version
-    SUBSTITUTE_VERSION=$(git describe --tags 2>/dev/null) \
-      || SUBSTITUTE_VERSION=$_JIKAN_API_VERSION
+    SUBSTITUTE_VERSION=$(git describe --tags 2>/dev/null || echo "$_JIKAN_API_VERSION")
   else
     # this is used when building locally
     SUBSTITUTE_VERSION=$(git describe --tags 2>/dev/null \
-      | sed -e "s/-[a-z0-9]\{8\}/-$(git rev-parse --short HEAD)/g") \
-      || SUBSTITUTE_VERSION=$_JIKAN_API_VERSION
+      | sed -e "s/-[a-z0-9]\{8\}/-$(git rev-parse --short HEAD)/g" \
+      || echo "$_JIKAN_API_VERSION")
   fi
 fi
 # set JIKAN_API_VERSION env var to "latest" or a tag which exists in the
@@ -119,7 +118,7 @@ ensure_secrets() {
   for secret_name in "${secrets[@]}"
   do
     if [ ! -f "$SECRETS_DIR/$secret_name.txt" ]; then
-      generated_secret=$(LC_ALL=c tr -dc 'A-Za-z0-9!()*+,\-;<=>_' </dev/urandom | head -c 16; echo)
+      generated_secret=$(LC_ALL=c tr -dc 'A-Za-z0-9!()*+,;<=>_-' </dev/urandom | head -c 16; echo)
       echo "$secret_name.txt not found, please provide a $secret_name [default is $generated_secret]:"
       # prompt for secret and save it in file
       read -r secret_value

--- a/container-setup.sh
+++ b/container-setup.sh
@@ -1,32 +1,36 @@
 #!/bin/bash
 
+set -euo pipefail
+
 _JIKAN_API_VERSION=v4.0.0
 SUBSTITUTE_VERSION=$_JIKAN_API_VERSION
 if [ -x "$(command -v git)" ]; then
   # check if we have checked out a tag or not
-  git symbolic-ref HEAD &> /dev/null
-  if [ $? -ne 0 ]; then
+  if ! git symbolic-ref HEAD &>/dev/null; then
     # if a tag is checked out then use the tag name as the version
-    SUBSTITUTE_VERSION=$(git describe --tags)
+    SUBSTITUTE_VERSION=$(git describe --tags 2>/dev/null) \
+      || SUBSTITUTE_VERSION=$_JIKAN_API_VERSION
   else
     # this is used when building locally
-    SUBSTITUTE_VERSION=$(git describe --tags | sed -e "s/-[a-z0-9]\{8\}/-$(git rev-parse --short HEAD)/g")
+    SUBSTITUTE_VERSION=$(git describe --tags 2>/dev/null \
+      | sed -e "s/-[a-z0-9]\{8\}/-$(git rev-parse --short HEAD)/g") \
+      || SUBSTITUTE_VERSION=$_JIKAN_API_VERSION
   fi
 fi
-# set JIKAN_API_VERSION env var to "latest" or a tag which exists in the container registry to use the remote image
-# otherwise docker compose will look for a locally builded image
-export _JIKAN_API_VERSION=${JIKAN_API_VERSION:-$SUBSTITUTE_VERSION}
-
+# set JIKAN_API_VERSION env var to "latest" or a tag which exists in the
+# container registry to use the remote image
+# otherwise docker compose will look for a locally built image
+export JIKAN_API_VERSION=${JIKAN_API_VERSION:-$SUBSTITUTE_VERSION}
 DOCKER_COMPOSE_PROJECT_NAME=jikan-api
 DOCKER_CMD="docker"
-DOCKER_COMPOSE_CMD="docker compose"
+DOCKER_COMPOSE_CMD=(docker compose)
 
 display_help() {
   echo "============================================================"
   echo "Jikan API Container Setup CLI"
   echo "============================================================"
   echo "Syntax: ./container-setup.sh [command]"
-  echo "Jikan API Version: $_JIKAN_API_VERSION"
+  echo "Jikan API Version: $JIKAN_API_VERSION"
   echo "---commands---"
   echo "help                   Print CLI help"
   echo "build-image            Build Image Locally"
@@ -40,142 +44,150 @@ display_help() {
 
 validate_prereqs() {
   docker_exists=$(command -v docker)
-  docker_compose_exists=$(command -v docker compose)
   podman_exists=$(command -v podman)
-  podman_compose_exists=$(command -v podman-compose)
 
-   if [ ! -x "$docker_exists" ] && [ ! -x "$podman_exists" ]; then
-      echo -e "'docker' is not installed. \xE2\x9D\x8C"
-      exit 1
-   else
-      echo -e "Docker is Installed. \xE2\x9C\x94"
-   fi
+  if [ ! -x "$docker_exists" ] && [ ! -x "$podman_exists" ]; then
+    echo -e "'docker' or 'podman' is not installed. \xE2\x9D\x8C"
+    exit 1
+  else
+    echo -e "Docker/Podman is Installed. \xE2\x9C\x94"
+  fi
 
-   if [ -x "$docker_exists" ]; then
-      DOCKER_CMD="docker"
-      docker -v >/dev/null 2>&1
-      if [ $? -ne 0 ]; then
-         echo -e "'docker' is not executable without sudo. \xE2\x9D\x8C"
-         exit 1
-      fi
-   elif [ -n "$podman_exists" ]; then
-      DOCKER_CMD="podman"
-   fi
-
-   if [ ! -x "$docker_compose_exists" ] && [ ! -x "$podman_compose_exists" ]; then
-       echo -e "'docker compose' is not installed. \xE2\x9D\x8C"
-       exit 1
-    else
-       echo -e "Docker compose is Installed. \xE2\x9C\x94"
-    fi
-
-    if [ -x "$docker_compose_exists" ]; then
-       DOCKER_COMPOSE_CMD="docker compose"
-    elif [ -x "$podman_compose_exists" ]; then
-       DOCKER_COMPOSE_CMD="podman-compose"
-    else
-      echo "Error"
+  if [ -x "$docker_exists" ]; then
+    DOCKER_CMD="docker"
+    if ! docker -v >/dev/null 2>&1; then
+      echo -e "'docker' is not executable without sudo. \xE2\x9D\x8C"
       exit 1
     fi
+    if docker compose version >/dev/null 2>&1; then
+      DOCKER_COMPOSE_CMD=(docker compose)
+      echo -e "Docker Compose is Installed. \xE2\x9C\x94"
+    else
+      echo -e "'docker compose' plugin is not installed. \xE2\x9D\x8C"
+      exit 1
+    fi
+  elif [ -x "$podman_exists" ]; then
+    DOCKER_CMD="podman"
+    if podman compose version >/dev/null 2>&1; then
+      DOCKER_COMPOSE_CMD=(podman compose)
+      echo -e "Podman Compose is Installed. \xE2\x9C\x94"
+    else
+      echo -e "'podman compose' is not available. \xE2\x9D\x8C"
+      exit 1
+    fi
+  fi
 }
 
 build_image() {
   validate_prereqs
-  $DOCKER_CMD inspect jikanme/jikan-rest:"$_JIKAN_API_VERSION" &> /dev/null && $DOCKER_CMD rmi jikanme/jikan-rest:"$_JIKAN_API_VERSION"
-  $DOCKER_CMD build --rm --compress -t jikanme/jikan-rest:"$_JIKAN_API_VERSION" .
-  $DOCKER_CMD tag jikanme/jikan-rest:"$_JIKAN_API_VERSION" jikanme/jikan-rest:latest
+  if $DOCKER_CMD inspect jikanme/jikan-rest:"$JIKAN_API_VERSION" &>/dev/null; then
+    if ! $DOCKER_CMD rmi jikanme/jikan-rest:"$JIKAN_API_VERSION"; then
+      echo -e "Warning: failed to remove existing image (it may be in use). \xE2\x9D\x8C"
+    fi
+  fi
+  $DOCKER_CMD build --rm -t jikanme/jikan-rest:"$JIKAN_API_VERSION" .
+  $DOCKER_CMD tag jikanme/jikan-rest:"$JIKAN_API_VERSION" jikanme/jikan-rest:latest
 }
 
 ensure_secrets() {
+  local SECRETS_DIR="${SECRETS_DIR:-.}"
+
   declare -a secrets=("db_password" "db_admin_password" "redis_password" "typesense_api_key")
 
-  if [ ! -f "db_username.txt" ]; then
+  if [ ! -f "$SECRETS_DIR/db_username.txt" ]; then
     echo "db_username.txt not found, please provide a db_username [default is jikan]:"
     read -r db_username
     if [ -z "$db_username" ]; then
       db_username="jikan"
     fi
-    echo -n "$db_username" > "db_username.txt"
+    echo -n "$db_username" > "$SECRETS_DIR/db_username.txt"
   else
-    echo -e "db_username.txt found, using it's value. \xE2\x9C\x94"
+    echo -e "db_username.txt found, using its value. \xE2\x9C\x94"
   fi
 
-  if [ ! -f "db_admin_username.txt" ]; then
+  if [ ! -f "$SECRETS_DIR/db_admin_username.txt" ]; then
     echo "db_admin_username.txt not found, please provide a db_admin_username [default is jikan_admin]:"
     read -r db_admin_username
     if [ -z "$db_admin_username" ]; then
       db_admin_username="jikan_admin"
     fi
-    echo -n "$db_admin_username" > "db_admin_username.txt"
+    echo -n "$db_admin_username" > "$SECRETS_DIR/db_admin_username.txt"
   else
-    echo -e "db_admin_username.txt found, using it's value. \xE2\x9C\x94"
+    echo -e "db_admin_username.txt found, using its value. \xE2\x9C\x94"
   fi
 
   for secret_name in "${secrets[@]}"
   do
-    if [ ! -f "$secret_name.txt" ]; then
-      if [ "$secret_name" == "db_username" ]; then
-        generated_secret="jikan"
-      else
-        generated_secret=$(LC_ALL=c tr -dc 'A-Za-z0-9!'\''()*+,-;<=>_' </dev/urandom | head -c 16  ; echo)
-      fi
+    if [ ! -f "$SECRETS_DIR/$secret_name.txt" ]; then
+      generated_secret=$(LC_ALL=c tr -dc 'A-Za-z0-9!()*+,\-;<=>_' </dev/urandom | head -c 16; echo)
       echo "$secret_name.txt not found, please provide a $secret_name [default is $generated_secret]:"
       # prompt for secret and save it in file
       read -r secret_value
       if [ -z "$secret_value" ]; then
         secret_value=$generated_secret
       fi
-      echo -n "$secret_value" > "$secret_name.txt"
+      echo -n "$secret_value" > "$SECRETS_DIR/$secret_name.txt"
     else
-      echo -e "$secret_name.txt found, using it's value. \xE2\x9C\x94"
+      echo -e "$secret_name.txt found, using its value. \xE2\x9C\x94"
     fi
   done
 }
 
 start() {
-   # todo: create a marker file for initial startup, and on initial startup ask the user whether they want a local image or the remote one
+  # todo: create a marker file for initial startup, and on initial startup ask
+  # the user whether they want a local image or the remote one
   validate_prereqs
   ensure_secrets
-  exec $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" up -d
+  "${DOCKER_COMPOSE_CMD[@]}" -p "$DOCKER_COMPOSE_PROJECT_NAME" up -d
 }
 
-case "$1" in
-   "help")
-      display_help
-      ;;
-   "validate-prereqs")
-      validate_prereqs
-      ;;
-   "build-image")
-      build_image
-      ;;
-   "start")
-      start
-      ;;
-   "stop")
-      validate_prereqs
-      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" down
-      ;;
-   "execute-indexers")
-      echo "Indexing anime..."
-      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:anime
-      echo "Indexing manga..."
-      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:manga
-      echo "Indexing characters and people..."
-      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:common
-      echo "Indexing genres..."
-      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:genres
-      echo "Indexing producers..."
-      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:producers
-      echo "Indexing done!"
-      ;;
-   "index-incrementally")
-      echo "Indexing..."
-      $DOCKER_COMPOSE_CMD -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:incremental anime manga
-      echo "Indexing done!"
-      ;;
-   *)
-      echo "No command specified, displaying help"
-      display_help
-      ;;
+if [ "$#" -gt 1 ]; then
+  echo "Error: too many arguments. Expected exactly one command."
+  display_help
+  exit 1
+fi
+
+case "${1:-}" in
+  "help")
+    display_help
+    ;;
+  "validate-prereqs")
+    validate_prereqs
+    ;;
+  "build-image")
+    build_image
+    ;;
+  "start")
+    start
+    ;;
+  "stop")
+    validate_prereqs
+    "${DOCKER_COMPOSE_CMD[@]}" -p "$DOCKER_COMPOSE_PROJECT_NAME" down
+    ;;
+  "execute-indexers")
+    validate_prereqs
+    ensure_secrets
+    echo "Indexing anime..."
+    "${DOCKER_COMPOSE_CMD[@]}" -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:anime
+    echo "Indexing manga..."
+    "${DOCKER_COMPOSE_CMD[@]}" -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:manga
+    echo "Indexing characters and people..."
+    "${DOCKER_COMPOSE_CMD[@]}" -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:common
+    echo "Indexing genres..."
+    "${DOCKER_COMPOSE_CMD[@]}" -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:genres
+    echo "Indexing producers..."
+    "${DOCKER_COMPOSE_CMD[@]}" -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:producers
+    echo "Indexing done!"
+    ;;
+  "index-incrementally")
+    validate_prereqs
+    ensure_secrets
+    echo "Indexing..."
+    "${DOCKER_COMPOSE_CMD[@]}" -p "$DOCKER_COMPOSE_PROJECT_NAME" exec jikan_rest php /app/artisan indexer:incremental anime manga
+    echo "Indexing done!"
+    ;;
+  *)
+    echo "No command specified, displaying help"
+    display_help
+    ;;
 esac

--- a/container-setup.sh
+++ b/container-setup.sh
@@ -14,12 +14,12 @@ if [ -x "$(command -v git)" ]; then
   fi
 fi
 # set JIKAN_API_VERSION env var to "latest" or a tag which exists in the container registry to use the remote image
-# otherwise docker-compose will look for a locally builded image
+# otherwise docker compose will look for a locally builded image
 export _JIKAN_API_VERSION=${JIKAN_API_VERSION:-$SUBSTITUTE_VERSION}
 
 DOCKER_COMPOSE_PROJECT_NAME=jikan-api
 DOCKER_CMD="docker"
-DOCKER_COMPOSE_CMD="docker-compose"
+DOCKER_COMPOSE_CMD="docker compose"
 
 display_help() {
   echo "============================================================"
@@ -32,7 +32,7 @@ display_help() {
   echo "build-image            Build Image Locally"
   echo "start                  Start Jikan API (mongodb, typesense, redis, jikan-api workers)"
   echo "stop                   Stop Jikan API"
-  echo "validate-prereqs       Validate pre-reqs installed (docker, docker-compose)"
+  echo "validate-prereqs       Validate pre-reqs installed (docker, docker compose)"
   echo "execute-indexers       Execute the indexers, which will scrape and index data from MAL. (Notice: This can take days)"
   echo "index-incrementally    Executes the incremental indexers for each media type. (anime, manga)"
   echo ""
@@ -40,7 +40,7 @@ display_help() {
 
 validate_prereqs() {
   docker_exists=$(command -v docker)
-  docker_compose_exists=$(command -v docker-compose)
+  docker_compose_exists=$(command -v docker compose)
   podman_exists=$(command -v podman)
   podman_compose_exists=$(command -v podman-compose)
 
@@ -63,14 +63,14 @@ validate_prereqs() {
    fi
 
    if [ ! -x "$docker_compose_exists" ] && [ ! -x "$podman_compose_exists" ]; then
-       echo -e "'docker-compose' is not installed. \xE2\x9D\x8C"
+       echo -e "'docker compose' is not installed. \xE2\x9D\x8C"
        exit 1
     else
        echo -e "Docker compose is Installed. \xE2\x9C\x94"
     fi
 
     if [ -x "$docker_compose_exists" ]; then
-       DOCKER_COMPOSE_CMD="docker-compose"
+       DOCKER_COMPOSE_CMD="docker compose"
     elif [ -x "$podman_compose_exists" ]; then
        DOCKER_COMPOSE_CMD="podman-compose"
     else

--- a/container-setup.sh
+++ b/container-setup.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -euo pipefail
 
 _JIKAN_API_VERSION=v4.0.0
 SUBSTITUTE_VERSION=$_JIKAN_API_VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     depends_on:
       mongodb: { condition: service_healthy }
       redis: { condition: service_healthy }
-      typesense: { condition: service_healthy }
+      typesense: { condition: service_started }
 
   mongodb:
     image: docker.io/mongo:focal
@@ -73,7 +73,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD_FILE: /run/secrets/db_admin_password
       MONGO_INITDB_DATABASE: jikan_admin
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh mongodb://localhost:27017 --quiet
+      test: [ 'CMD-SHELL', 'mongosh mongodb://localhost:27017 --quiet --eval "db.runCommand(\"ping\").ok"' ]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -94,7 +94,7 @@ services:
     ports:
       - '6379/tcp'
     healthcheck:
-      test: [ 'CMD', 'redis-cli', 'ping' ]
+      test: [ 'CMD-SHELL', 'redis-cli -a "$$(cat /run/secrets/redis_password)" ping | grep -q PONG' ]
       interval: 500ms
       timeout: 1s
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
+version: '3.8'
 volumes:
-  mongo-data: {}
-  redis-data: {}
-  typesense-data: {}
+  mongo-data: { }
+  redis-data: { }
+  typesense-data: { }
 
 networks:
-  jikan_network: {}
+  jikan_network: { }
 
 secrets:
   db_username:
@@ -22,7 +23,7 @@ secrets:
 
 services:
   jikan_rest:
-    image: "jikanme/jikan-rest:latest"
+    image: "docker.io/jikanme/jikan-rest:${_JIKAN_API_VERSION:-latest}"
     user: "${APP_UID:-10001}:${APP_GID:-10001}"
     networks:
       - jikan_network
@@ -36,14 +37,10 @@ services:
     env_file:
       - ./docker/config/.env.compose
     ports:
-      - "8000:8080/tcp"
+      - '8080:8080/tcp'
     hostname: jikan-rest-api
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          'wget --spider -q "http://127.0.0.1:2114/health?plugin=http"',
-        ]
+      test: [ 'CMD-SHELL', 'wget --spider -q "http://127.0.0.1:2114/health?plugin=http"' ]
       interval: 2s
       timeout: 2s
     links:
@@ -95,9 +92,9 @@ services:
     volumes:
       - redis-data:/data:rw
     ports:
-      - "6379/tcp"
+      - '6379/tcp'
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ 'CMD', 'redis-cli', 'ping' ]
       interval: 500ms
       timeout: 1s
 
@@ -119,7 +116,3 @@ services:
       - typesense-data:/data
     ports:
       - "8108/tcp"
-    healthcheck:
-      test: ["CMD", "echo", "healthy"]
-      interval: 10s
-      retries: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-version: '3.8'
 volumes:
-  mongo-data: { }
-  redis-data: { }
-  typesense-data: { }
+  mongo-data: {}
+  redis-data: {}
+  typesense-data: {}
 
 networks:
-  jikan_network: { }
+  jikan_network: {}
 
 secrets:
   db_username:
@@ -23,7 +22,7 @@ secrets:
 
 services:
   jikan_rest:
-    image: "docker.io/jikanme/jikan-rest:${_JIKAN_API_VERSION:-latest}"
+    image: "jikanme/jikan-rest:latest"
     user: "${APP_UID:-10001}:${APP_GID:-10001}"
     networks:
       - jikan_network
@@ -37,10 +36,14 @@ services:
     env_file:
       - ./docker/config/.env.compose
     ports:
-      - '8080:8080/tcp'
+      - "8000:8080/tcp"
     hostname: jikan-rest-api
     healthcheck:
-      test: [ 'CMD-SHELL', 'wget --spider -q "http://127.0.0.1:2114/health?plugin=http"' ]
+      test:
+        [
+          "CMD-SHELL",
+          'wget --spider -q "http://127.0.0.1:2114/health?plugin=http"',
+        ]
       interval: 2s
       timeout: 2s
     links:
@@ -92,9 +95,9 @@ services:
     volumes:
       - redis-data:/data:rw
     ports:
-      - '6379/tcp'
+      - "6379/tcp"
     healthcheck:
-      test: [ 'CMD', 'redis-cli', 'ping' ]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 500ms
       timeout: 1s
 
@@ -116,3 +119,7 @@ services:
       - typesense-data:/data
     ports:
       - "8108/tcp"
+    healthcheck:
+      test: ["CMD", "echo", "healthy"]
+      interval: 10s
+      retries: 1

--- a/docker/config/.env.compose
+++ b/docker/config/.env.compose
@@ -19,3 +19,4 @@ TYPESENSE_API_KEY__FILE=/run/secrets/typesense_api_key
 CORS_MIDDLEWARE=true
 MICROCACHING=true
 MICROCACHING_EXPIRE=60
+APP_URL=http://localhost:8080

--- a/docker/config/.env.compose
+++ b/docker/config/.env.compose
@@ -19,4 +19,3 @@ TYPESENSE_API_KEY__FILE=/run/secrets/typesense_api_key
 CORS_MIDDLEWARE=true
 MICROCACHING=true
 MICROCACHING_EXPIRE=60
-APP_URL=http://localhost:8080


### PR DESCRIPTION
Changes container-setup script to use docker compose instead of docker-compose.

- docker compose (with a space) is the modern, supported version (Compose V2)
- docker-compose (with a hyphen) is the legacy, deprecated version (Compose V1)

Newer developers will typically have docker compose installed.